### PR TITLE
docs: fix AI-Shifu logo links in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ markdown-flow-ui is part of the MarkdownFlow ecosystem for creating personalized
 
 <div align="center">
   <a href="https://ai-shifu.com">
-    <img src="https://ai-shifu.com/logo.png" alt="AI-Shifu" width="150" />
+    <img src="https://raw.githubusercontent.com/ai-shifu/ai-shifu/main/assets/logo_en.png" alt="AI-Shifu" width="150" />
   </a>
   <p><strong><a href="https://ai-shifu.com">AI-Shifu.com</a></strong></p>
   <p>AI-powered personalized learning platform</p>

--- a/README_ZH-CN.md
+++ b/README_ZH-CN.md
@@ -601,8 +601,8 @@ markdown-flow-ui 是 MarkdownFlow 生态系统的一部分，用于创建个性�
 ## 💖 赞助商
 
 <div align="center">
-  <a href="https://ai-shifu.com">
-    <img src="https://ai-shifu.com/logo.png" alt="AI-Shifu" width="150" />
+  <a href="https://ai-shifu.cn">
+    <img src="https://raw.githubusercontent.com/ai-shifu/ai-shifu/main/assets/logo_zh.png" alt="AI-Shifu" width="150" />
   </a>
   <p><strong><a href="https://ai-shifu.com">AI-Shifu.com</a></strong></p>
   <p>AI 驱动的个性化学习平台</p>

--- a/README_ZH-CN.md
+++ b/README_ZH-CN.md
@@ -604,7 +604,7 @@ markdown-flow-ui 是 MarkdownFlow 生态系统的一部分，用于创建个性�
   <a href="https://ai-shifu.cn">
     <img src="https://raw.githubusercontent.com/ai-shifu/ai-shifu/main/assets/logo_zh.png" alt="AI-Shifu" width="150" />
   </a>
-  <p><strong><a href="https://ai-shifu.com">AI-Shifu.com</a></strong></p>
+  <p><strong><a href="https://ai-shifu.cn">AI-Shifu.cn</a></strong></p>
   <p>AI 驱动的个性化学习平台</p>
 </div>
 

--- a/README_ZH-CN.md
+++ b/README_ZH-CN.md
@@ -602,7 +602,7 @@ markdown-flow-ui 是 MarkdownFlow 生态系统的一部分，用于创建个性�
 
 <div align="center">
   <a href="https://ai-shifu.cn">
-    <img src="https://raw.githubusercontent.com/ai-shifu/ai-shifu/main/assets/logo_zh.png" alt="AI-Shifu" width="150" />
+    <img src="https://raw.githubusercontent.com/ai-shifu/ai-shifu/main/assets/logo_zh.png" alt="AI 师傅" width="150" />
   </a>
   <p><strong><a href="https://ai-shifu.cn">AI-Shifu.cn</a></strong></p>
   <p>AI 驱动的个性化学习平台</p>


### PR DESCRIPTION
## Summary
- Updated AI-Shifu logo links to use images from the ai-shifu GitHub repository
- English README now uses `logo_en.png` 
- Chinese README now uses `logo_zh.png` and updated link to `ai-shifu.cn`

## Changes
- Replace direct website logo links with GitHub raw content URLs
- Use language-specific logos for better localization

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated branding assets in user-facing documentation: replaced logo images with new official assets for improved clarity and consistency.
  * Refreshed sponsorship sections in the Chinese documentation with updated sponsor link domain and localized logo, applied to both header and footer sections.
  * No functional changes; no impact on exports, APIs, or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->