### PR TITLE
fix: replace 'any' types with proper TypeScript definitions

### DIFF
--- a/src/components/ContentRender/ContentRender.tsx
+++ b/src/components/ContentRender/ContentRender.tsx
@@ -22,6 +22,13 @@ import { OnSendContentParams, CustomRenderBarProps } from "../types";
 import remarkBreaks from "remark-breaks";
 import { processMarkdownText } from "./utils/process-markdown";
 
+// Define types for markdown components
+interface CodeProps extends React.HTMLAttributes<HTMLElement> {
+  inline?: boolean;
+  className?: string;
+  children?: React.ReactNode;
+}
+
 // Define component Props type
 export interface ContentRenderProps {
   content: string;
@@ -69,8 +76,8 @@ const ContentRender: React.FC<ContentRenderProps> = ({
         tooltipMinLength={tooltipMinLength}
       />
     ),
-    code: (props) => {
-      const { inline, className, children, ...rest } = props as any;
+    code: (props: CodeProps) => {
+      const { inline, className, children, ...rest } = props;
       const match = /language-(\w+)/.exec(className || "");
       const language = match ? match[1] : "";
 

--- a/src/components/ContentRender/plugins_bac/remark-custom-button.ts
+++ b/src/components/ContentRender/plugins_bac/remark-custom-button.ts
@@ -6,7 +6,7 @@ interface CustomButtonNode extends Node {
   type: "element";
   data?: {
     hName?: string;
-    hProperties?: Record<string, any>;
+    hProperties?: Record<string, unknown>;
     hChildren?: Array<{ type: string; value: string }>;
   };
 }

--- a/src/components/ContentRender/plugins_bac/remark-custom-variable.ts
+++ b/src/components/ContentRender/plugins_bac/remark-custom-variable.ts
@@ -196,7 +196,6 @@ export default function remarkCustomButtonInputVariable() {
           // Replace the original node
           parent.children.splice(index, 1, ...segments);
         } catch (error) {
-          // eslint-disable-next-line no-console
           console.warn("Failed to parse custom variable syntax:", error);
           // If parsing fails, keep the original content
           return;

--- a/src/components/MarkdownFlow/useScrollToBottom.ts
+++ b/src/components/MarkdownFlow/useScrollToBottom.ts
@@ -17,7 +17,7 @@ interface UseScrollToBottomReturn {
 
 const useScrollToBottom = (
   containerRef: RefObject<HTMLDivElement | null>,
-  dependencies: any[] = [],
+  dependencies: unknown[] = [],
   options: UseScrollToBottomOptions = {}
 ): UseScrollToBottomReturn => {
   const {

--- a/src/components/Playground/Playground.tsx
+++ b/src/components/Playground/Playground.tsx
@@ -6,10 +6,20 @@ import { ContentRenderProps } from "../ContentRender/ContentRender";
 import { OnSendContentParams, CustomRenderBarProps } from "../types";
 import { Loader } from "lucide-react";
 
+// Define proper types for variables
+type VariableValue = string | number | boolean | null | undefined;
+
+// Define type for SSE response data
+interface SSEData {
+  content?: string;
+  status?: string;
+  [key: string]: unknown;
+}
+
 type PlaygroundComponentProps = {
   defaultContent: string;
   defaultVariables?: {
-    [key: string]: any;
+    [key: string]: VariableValue;
   };
   defaultDocumentPrompt?: string;
   styles?: React.CSSProperties;
@@ -26,7 +36,7 @@ type SSEParams = {
     content: string;
   }>;
   variables?: {
-    [key: string]: any;
+    [key: string]: VariableValue;
   };
   user_input: string | null;
   document_prompt: string | null;
@@ -223,7 +233,7 @@ const PlaygroundComponent: React.FC<PlaygroundComponentProps> = ({
     return list;
   };
 
-  const { data, connect } = useSSE<any>(sseUrl, {
+  const { data, connect } = useSSE<SSEData>(sseUrl, {
     method: "POST",
     body: getSSEBody(),
     headers: sessionId ? { "session-id": sessionId } : {},
@@ -244,7 +254,6 @@ const PlaygroundComponent: React.FC<PlaygroundComponentProps> = ({
         const updatedList = updateContentListWithSseData(data);
         setContentList(updatedList);
       } catch (error) {
-        // eslint-disable-next-line no-console
         console.error("Error processing SSE message:", error);
       }
     }

--- a/src/components/Playground/useMarkdownInfo.ts
+++ b/src/components/Playground/useMarkdownInfo.ts
@@ -50,8 +50,10 @@ const useMarkdownInfo = (content: string) => {
         } else {
           setError(result.message || "Request failed");
         }
-      } catch (err: any) {
-        setError(err.message || "Network error");
+      } catch (err: unknown) {
+        const errorMessage =
+          err instanceof Error ? err.message : "Network error";
+        setError(errorMessage);
       } finally {
         setLoading(false);
       }

--- a/src/components/sse/useSSE.ts
+++ b/src/components/sse/useSSE.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { fetchEventSource } from "@microsoft/fetch-event-source";
 
-interface UseSSEReturn<T = any> {
+interface UseSSEReturn<T = unknown> {
   data: T | null;
   isLoading: boolean;
   error: Error | null;
@@ -15,7 +15,7 @@ const FINISHED_MESSAGE = "[DONE]";
 interface UseSSEOptions extends RequestInit {
   autoConnect?: boolean;
   onStart?: (index: number) => void;
-  onFinish?: (finalData: any, index: number) => void;
+  onFinish?: (finalData: unknown, index: number) => void;
   maxRetries?: number;
   retryDelay?: number;
 }
@@ -27,7 +27,7 @@ type ConnectionState =
   | "error"
   | "closed";
 
-const useSSE = <T = any>(
+const useSSE = <T = unknown>(
   url: string,
   options: UseSSEOptions = {}
 ): UseSSEReturn<T> => {
@@ -113,11 +113,10 @@ const useSSE = <T = any>(
               return;
             }
             try {
-              const parsedData: any = event.data;
+              const parsedData: string = event.data;
               finalDataRef.current += parsedData;
-              setData(finalDataRef.current as any);
+              setData(finalDataRef.current as T);
             } catch (err) {
-              // eslint-disable-next-line no-console
               console.warn("Failed to process SSE message:", err);
             }
           }


### PR DESCRIPTION
## Summary
- Replaced all `any` types with proper TypeScript definitions across the codebase
- Added proper interface definitions for React components and SSE data handling
- Improved type safety by using `unknown` instead of `any` where appropriate
- Removed unused ESLint disable directives

## Changes Made
- **ContentRender.tsx**: Added `CodeProps` interface for markdown code components
- **useScrollToBottom.ts**: Changed `any[]` to `unknown[]` for dependencies
- **Playground.tsx**: Created `VariableValue` and `SSEData` types for proper typing
- **useMarkdownInfo.ts**: Improved error handling with proper type guards
- **useSSE.ts**: Updated all generic defaults from `any` to `unknown`
- **plugins_bac**: Updated Record types to use `unknown` instead of `any`

## Test plan
- [x] All lint checks pass without warnings
- [x] TypeScript compilation successful
- [x] Code formatting applied correctly
- [x] Pre-commit hooks pass successfully

🤖 Generated with [Claude Code](https://claude.ai/code)