### PR TITLE
feat: add input length limit with default of 140 characters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,11 @@ repos:
     hooks:
       - id: eslint
         name: ESLint
-        entry: bash -c 'npm run lint -- --fix --max-warnings 20 --file $(echo "$@" | tr " " "\n" | grep -E "\.(js|jsx|ts|tsx)$") || true' --
-        language: system
+        entry: bash -c 'npx next lint --fix --max-warnings 20 --file $(echo "$@" | tr " " "\n" | grep -E "\.(js|jsx|ts|tsx)$") || true' --
+        language: node
         files: ^src/.*\.(js|jsx|ts|tsx)$
         pass_filenames: true
+        additional_dependencies: ["eslint@^9", "next@15.3.5"]
       - id: prettier
         name: Prettier
         entry: prettier

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -14,12 +14,14 @@ interface MarkdownFlowProps {
   typingSpeed?: number;
   enableTypewriter?: boolean;
   onBlockComplete?: (blockIndex: number) => void;
+  defaultInputMaxLength?: number; // Default max length for input fields (override with node-specific maxLength), defaults to 140
 }
 
 type ContentItem = {
   content: string;
   isFinished?: boolean;
   defaultInputText?: string;
+  defaultInputTextMaxLength?: number; // Max length for this specific content block (overrides defaultInputMaxLength)
   defaultButtonText?: string;
   readonly?: boolean;
   customRenderBar?: CustomRenderBarProps;
@@ -40,6 +42,7 @@ type OnSendContentParams = {
 - `onSend` - Callback for user interactions
 - `onBlockComplete` - Called when a block finishes typing
 - `customRenderBar` - Custom component for additional UI
+- `defaultInputMaxLength` - Default maximum length for input fields (override with node-specific maxLength), defaults to 140
 
 **Example:**
 
@@ -106,6 +109,7 @@ interface ContentRenderProps {
   enableTypewriter?: boolean;
   defaultButtonText?: string;
   defaultInputText?: string;
+  defaultInputMaxLength?: number; // Default max length for input fields (override with node-specific maxLength), defaults to 140
   readonly?: boolean;
   onTypeFinished?: () => void;
 }
@@ -118,6 +122,7 @@ interface ContentRenderProps {
 - `enableTypewriter` - Enable animation (default: false)
 - `readonly` - Make interactive elements read-only
 - `onTypeFinished` - Called when typing completes
+- `defaultInputMaxLength` - Default maximum length for input fields (override with node-specific maxLength), defaults to 140
 
 **Supported Markdown:**
 
@@ -151,6 +156,44 @@ graph LR
     B --> C
 ```
 ````
+
+**Input Length Limitation:**
+
+When using remark-flow syntax, length limits are controlled through the component properties. By default, all input fields are limited to 140 characters unless overridden. To limit input length for specific content blocks:
+
+1. Use `defaultInputMaxLength` prop on MarkdownFlow or ContentRender components for global limits (default: 140)
+2. Use `defaultInputTextMaxLength` in individual content items for block-specific limits
+3. The node-specific maxLength (if supported by remark-flow) takes highest priority
+4. Then comes content-item specific limit
+5. Finally, the global default
+
+Examples:
+
+```tsx
+<MarkdownFlow
+  defaultInputMaxLength={100} // Global default (overrides the 140 default)
+  initialContentList={[
+    {
+      content: "Limited to 50 chars: ?[%{{input1}} Enter text...]",
+      defaultInputTextMaxLength: 50, // Override global default
+    },
+    {
+      content: "Uses global default: ?[%{{input2}} Enter more text...]",
+      // Will use default of 100 chars (not the 140 default),
+    },
+  ]}
+/>
+
+// With default 140 character limit:
+<MarkdownFlow
+  initialContentList={[
+    {
+      content: "Uses default 140 char limit: ?[%{{input1}} Enter text...]",
+      // Will use default of 140 chars,
+    },
+  ]}
+/>
+```
 
 ## Hooks
 

--- a/src/components/ContentRender/ContentRender.tsx
+++ b/src/components/ContentRender/ContentRender.tsx
@@ -49,6 +49,7 @@ export interface ContentRenderProps {
   defaultButtonText?: string;
   defaultInputText?: string; // Text input by user
   defaultSelectedValues?: string[]; // Default selected values for multi-select
+  defaultInputMaxLength?: number; // Default max length for input fields (override with node-specific maxLength), defaults to 140
   readonly?: boolean;
   onTypeFinished?: () => void;
   // Multi-select confirm button text (i18n support)
@@ -73,6 +74,7 @@ const ContentRender: React.FC<ContentRenderProps> = ({
   enableTypewriter = false,
   defaultButtonText,
   defaultInputText,
+  defaultInputMaxLength = 140, // 默认最大输入长度为140个字符
   defaultSelectedValues,
   readonly = false,
   onTypeFinished,
@@ -109,6 +111,7 @@ const ContentRender: React.FC<ContentRenderProps> = ({
         defaultButtonText={defaultButtonText}
         defaultInputText={defaultInputText}
         defaultSelectedValues={defaultSelectedValues}
+        defaultInputMaxLength={defaultInputMaxLength}
         onSend={onSend}
         confirmButtonText={confirmButtonText}
         // tooltipMinLength={tooltipMinLength}

--- a/src/components/ContentRender/ContentRender.tsx
+++ b/src/components/ContentRender/ContentRender.tsx
@@ -74,7 +74,7 @@ const ContentRender: React.FC<ContentRenderProps> = ({
   enableTypewriter = false,
   defaultButtonText,
   defaultInputText,
-  defaultInputMaxLength = 140, // 默认最大输入长度为140个字符
+  defaultInputMaxLength = 140, // Default max input length is 140 characters
   defaultSelectedValues,
   readonly = false,
   onTypeFinished,

--- a/src/components/ContentRender/plugins/CustomVariable.tsx
+++ b/src/components/ContentRender/plugins/CustomVariable.tsx
@@ -15,6 +15,7 @@ interface CustomVariableNode {
     buttonValues?: string[];
     placeholder?: string;
     isMultiSelect?: boolean;
+    maxLength?: number;
   };
 }
 
@@ -24,6 +25,7 @@ interface CustomVariableProps {
   defaultButtonText?: string;
   defaultInputText?: string;
   defaultSelectedValues?: string[];
+  defaultInputMaxLength?: number;
   readonly?: boolean;
   onSend?: (content: OnSendContentParams) => void;
   // Multi-select confirm button text (i18n support)
@@ -41,6 +43,7 @@ const CustomButtonInputVariable = ({
   defaultButtonText,
   defaultInputText,
   defaultSelectedValues,
+  defaultInputMaxLength,
   onSend,
   confirmButtonText = "Confirm", // Default to English, can be overridden
 }: CustomVariableProps) => {
@@ -78,7 +81,15 @@ const CustomButtonInputVariable = ({
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setInputValue(e.target.value);
+    const value = e.target.value;
+    const maxLength = node.properties?.maxLength || defaultInputMaxLength;
+
+    if (maxLength && value.length > maxLength) {
+      // Truncate to maxLength if exceeded
+      setInputValue(value.substring(0, maxLength));
+    } else {
+      setInputValue(value);
+    }
   };
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
@@ -129,6 +140,7 @@ const CustomButtonInputVariable = ({
                 value={inputValue}
                 onChange={handleInputChange}
                 onKeyDown={handleKeyDown}
+                maxLength={node.properties?.maxLength || defaultInputMaxLength}
                 className="flex-1 h-8 text-sm border-0 shadow-none outline-none ring-0"
                 title={node.properties.placeholder}
               />
@@ -188,6 +200,7 @@ const CustomButtonInputVariable = ({
             value={inputValue}
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
+            maxLength={node.properties?.maxLength || defaultInputMaxLength}
             className="w-50 h-8 text-sm border-0 shadow-none outline-none ring-0"
             style={{
               border: "none",

--- a/src/components/MarkdownFlow/MarkdownFlow.tsx
+++ b/src/components/MarkdownFlow/MarkdownFlow.tsx
@@ -33,7 +33,7 @@ const MarkdownFlow: React.FC<MarkdownFlowProps> = ({
   typingSpeed: typingSpeedProp,
   enableTypewriter = false,
   onBlockComplete,
-  defaultInputMaxLength = 140, // 默认最大输入长度为140个字符
+  defaultInputMaxLength = 140, // Default max input length is 140 characters
   confirmButtonText,
 }) => {
   return (

--- a/src/components/MarkdownFlow/MarkdownFlow.tsx
+++ b/src/components/MarkdownFlow/MarkdownFlow.tsx
@@ -8,6 +8,7 @@ export interface MarkdownFlowProps {
     content: string;
     isFinished?: boolean;
     defaultInputText?: string;
+    defaultInputTextMaxLength?: number; // Max length for this specific content block
     defaultButtonText?: string;
     defaultSelectedValues?: string[];
     readonly?: boolean;
@@ -20,6 +21,7 @@ export interface MarkdownFlowProps {
   typingSpeed?: number;
   enableTypewriter?: boolean;
   onBlockComplete?: (blockIndex: number) => void;
+  defaultInputMaxLength?: number; // Default max length for all input fields
   // Multi-select confirm button text (i18n support)
   confirmButtonText?: string;
 }
@@ -31,6 +33,7 @@ const MarkdownFlow: React.FC<MarkdownFlowProps> = ({
   typingSpeed: typingSpeedProp,
   enableTypewriter = false,
   onBlockComplete,
+  defaultInputMaxLength = 140, // 默认最大输入长度为140个字符
   confirmButtonText,
 }) => {
   return (
@@ -45,6 +48,9 @@ const MarkdownFlow: React.FC<MarkdownFlowProps> = ({
             key={index}
             content={contentInfo.content}
             defaultInputText={contentInfo.defaultInputText}
+            defaultInputMaxLength={
+              contentInfo.defaultInputTextMaxLength || defaultInputMaxLength
+            }
             defaultButtonText={contentInfo.defaultButtonText}
             defaultSelectedValues={contentInfo.defaultSelectedValues}
             readonly={contentInfo.readonly}


### PR DESCRIPTION
- Add defaultInputMaxLength prop to MarkdownFlow and ContentRender components with default value of 140
- Add defaultInputTextMaxLength prop to individual content items for block-specific limits
- Implement input length validation in CustomVariable component with dual protection (browser native + React state)
- Update documentation to reflect default 140 character limit and usage examples
- Priority order: node-specific maxLength > content-item specific maxLength > global default (140)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable input length limits at three levels: global default (140), per-block override, and node-specific limits.
  * Hierarchical resolution so more specific settings override broader defaults.
  * Inputs now enforce/truncate to the applicable max length for consistent behavior.

* **Documentation**
  * API docs updated with new public properties, guidance and examples showing priority order and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->