### PR TITLE
fix(content-render): highlight default button by value before label

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,5 +146,5 @@
     "test": "echo \"No tests specified\" && exit 0"
   },
   "types": "dist/index.d.ts",
-  "version": "0.1.28"
+  "version": "0.1.29"
 }

--- a/src/components/ContentRender/plugins/CustomVariable.tsx
+++ b/src/components/ContentRender/plugins/CustomVariable.tsx
@@ -96,6 +96,28 @@ const CustomButtonInputVariable = ({
       inputText: inputValue,
     });
   };
+
+  const resolvedDefaultButtonText = React.useMemo(() => {
+    if (!defaultButtonText) {
+      return undefined;
+    }
+    const buttonTexts = node.properties?.buttonTexts || [];
+    const buttonValues = node.properties?.buttonValues || [];
+    const valueIndex = buttonValues.indexOf(defaultButtonText);
+    if (valueIndex > -1) {
+      return buttonTexts[valueIndex] ?? defaultButtonText;
+    }
+    const textIndex = buttonTexts.indexOf(defaultButtonText);
+    if (textIndex > -1) {
+      return buttonTexts[textIndex];
+    }
+    return undefined;
+  }, [
+    defaultButtonText,
+    node.properties?.buttonTexts,
+    node.properties?.buttonValues,
+  ]);
+
   return (
     <span className="custom-variable-container inline-flex items-center gap-2 flex-wrap">
       {isMultiSelect ? (
@@ -164,11 +186,11 @@ const CustomButtonInputVariable = ({
               className={`cursor-pointer h-8 text-sm hover:bg-gray-200`}
               style={{
                 backgroundColor:
-                  defaultButtonText === text
+                  resolvedDefaultButtonText === text
                     ? "var(--primary, #2563eb)"
                     : undefined,
                 color:
-                  defaultButtonText === text
+                  resolvedDefaultButtonText === text
                     ? "var(--primary-foreground, white)"
                     : undefined,
               }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed button styling for custom variable single-select controls to correctly display the active button state when button text mappings are configured.

* **Chores**
  * Updated package version to 0.1.29.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->