### PR TITLE
fix(sandbox): hide phantom scrollbar and prevent vh-feedback height runaway

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
       ]
     }
   },
-  "version": "0.1.117",
+  "version": "0.1.119",
   "type": "module",
   "exports": {
     ".": {

--- a/src/components/ContentRender/IframeSandbox.tsx
+++ b/src/components/ContentRender/IframeSandbox.tsx
@@ -442,6 +442,12 @@ const IframeSandbox: React.FC<IframeSandboxProps> = ({
 
         if (cw > 0) {
           const minH = Math.round((cw * 9) / 16);
+          // Absolute height cap. Diverging vh-feedback (multiple `height:100vh`
+          // siblings, or compound vh-relative children whose sum exceeds the
+          // viewport) can otherwise grow the iframe geometrically across
+          // repeated ResizeObserver/MutationObserver passes. 1:20 aspect is
+          // a generous upper bound for any single sandbox slide.
+          const maxH = Math.max(8192, cw * 20);
           iframe.style.height = minH + "px";
           // eslint-disable-next-line @typescript-eslint/no-unused-expressions
           doc.body.offsetHeight; // force layout
@@ -493,6 +499,12 @@ const IframeSandbox: React.FC<IframeSandboxProps> = ({
                 getInnerScrollableHeight(doc.body)
               );
               if (nextH <= measuredH + 1) break; // stable — stop iterating
+              // Geometric vh-feedback detection: vh-relative children scale
+              // with the iframe viewport, so growing the iframe makes them
+              // larger which grows scrollHeight — runaway divergence. Two
+              // `height:100vh` siblings produce a 2× per-iteration multiplier.
+              // Stop iterating; keep the prior (stable) measuredH.
+              if (nextH >= measuredH * 1.5) break;
               measuredH = nextH;
             }
           }
@@ -501,7 +513,7 @@ const IframeSandbox: React.FC<IframeSandboxProps> = ({
           iframe.style.height = prevH;
 
           setContentHeight((prev) => {
-            const next = Math.max(200, Math.ceil(measuredH));
+            const next = Math.min(maxH, Math.max(200, Math.ceil(measuredH)));
             return prev === next ? prev : next;
           });
         }

--- a/src/components/ContentRender/SandboxApp.tsx
+++ b/src/components/ContentRender/SandboxApp.tsx
@@ -153,6 +153,11 @@ const SandboxApp: React.FC<SandboxAppProps> = ({
       .sandbox-container { position: relative; width: 100%; }
       .sandbox-container svg,
       .sandbox-container img { display: block; margin-left: auto; margin-right: auto; }
+      /* Sub-pixel rounding (clamp() font-size + fractional flex children) can push
+         scrollHeight 1px past clientHeight, producing a phantom scrollbar on a root
+         that visually fits. The user content root inside .sandbox-container should
+         never render its own scrollbar; the iframe boundary handles overflow. */
+      .sandbox-container > * { overflow: clip !important; }
       .justify-\\[safe_center\\]{
         justify-content: safe center;
       }

--- a/src/components/ContentRender/SandboxApp.tsx
+++ b/src/components/ContentRender/SandboxApp.tsx
@@ -153,11 +153,16 @@ const SandboxApp: React.FC<SandboxAppProps> = ({
       .sandbox-container { position: relative; width: 100%; }
       .sandbox-container svg,
       .sandbox-container img { display: block; margin-left: auto; margin-right: auto; }
-      /* Sub-pixel rounding (clamp() font-size + fractional flex children) can push
-         scrollHeight 1px past clientHeight, producing a phantom scrollbar on a root
-         that visually fits. The user content root inside .sandbox-container should
-         never render its own scrollbar; the iframe boundary handles overflow. */
-      .sandbox-container > * { overflow: clip !important; }
+      /* Hide scroll UI without removing scroll semantics. Content roots with
+         inline style="height:100vh; overflow-y:auto" are the signal that
+         IframeSandbox.getInnerScrollableHeight relies on to grow the iframe
+         when content exceeds the viewport. We must not change overflow-y,
+         but sub-pixel rounding (1px below the +1 detection threshold) can
+         still surface a phantom scrollbar on content that visually fits.
+         Hide the scrollbar UI globally; when content truly overflows the
+         iframe is resized and no scrollbar would render anyway. */
+      .sandbox-container *::-webkit-scrollbar { display: none; }
+      .sandbox-container * { scrollbar-width: none; -ms-overflow-style: none; }
       .justify-\\[safe_center\\]{
         justify-content: safe center;
       }


### PR DESCRIPTION
  - Hide scrollbar UI on .sandbox-container descendants without changing
    overflow semantics. Sub-pixel rounding (clamp() font-size + fractional
    flex children) pushed scrollHeight 1px past clientHeight on user roots
    with inline overflow-y:auto, surfacing a phantom scrollbar on content
    that visually fit. Keeping overflow-y:auto intact preserves the signal
    IframeSandbox.getInnerScrollableHeight uses to measure real overflow.

  - Add geometric-feedback protection to the content-mode measurement
    loop in IframeSandbox. Multiple `height:100vh` sibling roots under
    .sandbox-container caused body.scrollHeight to double per iteration,
    growing the iframe to >280,000px. Break on >=1.5x single-step growth
    (signature of vh divergence) and cap final content height at
    max(8192, cw*20) as defense in depth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iframe content height measurement to provide more stable and predictable sizing across different content types
  * Enhanced safeguards to prevent excessive height growth in embedded content containers
  * Removed phantom scrollbars from sandboxed content displays for a cleaner visual experience

* **Chores**
  * Version update

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/markdown-flow-ui/pull/147)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->