### PR TITLE
fix: keep slide shortcuts from waking controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-flow-ui",
-  "version": "0.1.125",
+  "version": "0.1.126",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-flow-ui",
-      "version": "0.1.125",
+      "version": "0.1.126",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
       ]
     }
   },
-  "version": "0.1.125",
+  "version": "0.1.126",
   "type": "module",
   "exports": {
     ".": {

--- a/src/components/Slide/Player.tsx
+++ b/src/components/Slide/Player.tsx
@@ -48,6 +48,7 @@ import {
 } from "./utils/playbackSource";
 import { shouldKeepPlayingAfterNavigation } from "./utils/playbackPreference";
 import { toPlayerCustomActionList } from "./utils/playerCustomActions";
+import { suppressPlayerControlsWakeAfterNavigation } from "./utils/playerNavigationContext";
 import "./player.css";
 
 const audioPreloadElementCache = new Map<string, HTMLAudioElement>();
@@ -90,6 +91,8 @@ export type SlidePlayerLoadingReason = "loadingAudio" | "waitingForMoreAudio";
 
 export interface SlidePlayerNavigationContext {
   shouldContinuePlayback: boolean;
+  /** Set false when navigation should not reveal hidden player controls. */
+  shouldWakeControls?: boolean;
 }
 
 const preloadAudioUrl = (url?: string) => {
@@ -873,10 +876,10 @@ const Player = ({
     if (isPlaybackPaused) {
       wasPlayingBeforeExternalPauseRef.current = Boolean(
         currentAudioRef.current &&
-        !isPausedByUserRef.current &&
-        (!audioElement.paused ||
-          pendingAutoPlayRef.current ||
-          waitingSegmentIndexRef.current !== null)
+          !isPausedByUserRef.current &&
+          (!audioElement.paused ||
+            pendingAutoPlayRef.current ||
+            waitingSegmentIndexRef.current !== null)
       );
 
       pendingAutoPlayRef.current = false;
@@ -1326,7 +1329,9 @@ const Player = ({
         }
 
         if (!nextDisabled) {
-          onNext(getNavigationContext());
+          onNext(
+            suppressPlayerControlsWakeAfterNavigation(getNavigationContext())
+          );
         }
 
         return true;
@@ -1337,7 +1342,9 @@ const Player = ({
         }
 
         if (!prevDisabled) {
-          onPrev(getNavigationContext());
+          onPrev(
+            suppressPlayerControlsWakeAfterNavigation(getNavigationContext())
+          );
         }
 
         return true;

--- a/src/components/Slide/Player.tsx
+++ b/src/components/Slide/Player.tsx
@@ -876,10 +876,10 @@ const Player = ({
     if (isPlaybackPaused) {
       wasPlayingBeforeExternalPauseRef.current = Boolean(
         currentAudioRef.current &&
-          !isPausedByUserRef.current &&
-          (!audioElement.paused ||
-            pendingAutoPlayRef.current ||
-            waitingSegmentIndexRef.current !== null)
+        !isPausedByUserRef.current &&
+        (!audioElement.paused ||
+          pendingAutoPlayRef.current ||
+          waitingSegmentIndexRef.current !== null)
       );
 
       pendingAutoPlayRef.current = false;

--- a/src/components/Slide/Slide.tsx
+++ b/src/components/Slide/Slide.tsx
@@ -45,6 +45,7 @@ import {
   type MobileViewMode,
 } from "./utils/mobileScreenMode";
 import { shouldPresentInteractionOverlay } from "./utils/interactionPlayback";
+import { shouldWakePlayerControlsAfterNavigation } from "./utils/playerNavigationContext";
 import { shouldAutoAdvanceIntoAppendedMarker } from "./utils/appendedMarkerAdvance";
 import { getPlaybackSequenceTransition } from "./utils/playbackSequence";
 import {
@@ -124,10 +125,11 @@ interface InteractionOverlayCardProps {
   readonly?: boolean;
 }
 
-export interface SlideInteractionTexts extends Pick<
-  ContentRenderProps,
-  "confirmButtonText" | "copyButtonText" | "copiedButtonText"
-> {
+export interface SlideInteractionTexts
+  extends Pick<
+    ContentRenderProps,
+    "confirmButtonText" | "copyButtonText" | "copiedButtonText"
+  > {
   title?: string;
 }
 
@@ -713,7 +715,7 @@ const Slide: React.FC<SlideProps> = ({
 
   const hasResolvedCurrentInteraction = Boolean(
     currentInteractionElement?.readonly ||
-    currentInteractionElement?.user_input?.trim()
+      currentInteractionElement?.user_input?.trim()
   );
 
   const shouldBlockPlaybackForInteraction =
@@ -908,6 +910,7 @@ const Slide: React.FC<SlideProps> = ({
     sectionRef,
     enabled: shouldRenderPlayer,
     keyboardShortcutsEnabled: enableKeyboardShortcuts,
+    onKeyboardShortcut: activateKeyboardShortcutOwner,
     onWake: () => {
       activateKeyboardShortcutOwner();
       setHasPlayerInteracted(true);
@@ -1384,9 +1387,11 @@ const Slide: React.FC<SlideProps> = ({
       syncPlaybackPreferenceBeforeNavigation(context);
       shouldScrollToBottomRef.current = true;
       pendingInteractionOverlayStepIndexRef.current = null;
-      setHasPlayerInteracted(true);
       setIsAudioLoadingVisible(false);
-      showPlayerControls(true);
+      if (shouldWakePlayerControlsAfterNavigation(context)) {
+        setHasPlayerInteracted(true);
+        showPlayerControls(true);
+      }
       resetAudioSequence();
       goPrev();
     },
@@ -1403,9 +1408,11 @@ const Slide: React.FC<SlideProps> = ({
       syncPlaybackPreferenceBeforeNavigation(context);
       shouldScrollToBottomRef.current = true;
       pendingInteractionOverlayStepIndexRef.current = null;
-      setHasPlayerInteracted(true);
       setIsAudioLoadingVisible(false);
-      showPlayerControls(true);
+      if (shouldWakePlayerControlsAfterNavigation(context)) {
+        setHasPlayerInteracted(true);
+        showPlayerControls(true);
+      }
       resetAudioSequence();
       goNext();
     },

--- a/src/components/Slide/Slide.tsx
+++ b/src/components/Slide/Slide.tsx
@@ -125,11 +125,10 @@ interface InteractionOverlayCardProps {
   readonly?: boolean;
 }
 
-export interface SlideInteractionTexts
-  extends Pick<
-    ContentRenderProps,
-    "confirmButtonText" | "copyButtonText" | "copiedButtonText"
-  > {
+export interface SlideInteractionTexts extends Pick<
+  ContentRenderProps,
+  "confirmButtonText" | "copyButtonText" | "copiedButtonText"
+> {
   title?: string;
 }
 
@@ -715,7 +714,7 @@ const Slide: React.FC<SlideProps> = ({
 
   const hasResolvedCurrentInteraction = Boolean(
     currentInteractionElement?.readonly ||
-      currentInteractionElement?.user_input?.trim()
+    currentInteractionElement?.user_input?.trim()
   );
 
   const shouldBlockPlaybackForInteraction =

--- a/src/components/Slide/useWakePlayerFromIframe.ts
+++ b/src/components/Slide/useWakePlayerFromIframe.ts
@@ -9,6 +9,7 @@ type UseWakePlayerFromIframeParams = {
   sectionRef: React.RefObject<HTMLElement | null>;
   enabled: boolean;
   keyboardShortcutsEnabled?: boolean;
+  onKeyboardShortcut?: () => void;
   onWake: () => void;
 };
 
@@ -19,6 +20,7 @@ type UseWakePlayerFromIframeParams = {
  * @param params.sectionRef - Section element used to scope iframe wake events and host shortcut dispatch.
  * @param params.enabled - Enables or disables iframe wake handling.
  * @param params.keyboardShortcutsEnabled - Enables or disables iframe keyboard shortcut forwarding. Defaults to true.
+ * @param params.onKeyboardShortcut - Callback invoked before iframe keyboard shortcuts are forwarded.
  * @param params.onWake - Callback invoked when iframe interaction should restore player controls.
  * @returns void
  */
@@ -26,10 +28,12 @@ const useWakePlayerFromIframe = ({
   sectionRef,
   enabled,
   keyboardShortcutsEnabled = true,
+  onKeyboardShortcut,
   onWake,
 }: UseWakePlayerFromIframeParams) => {
   const enabledRef = useRef(enabled);
   const keyboardShortcutsEnabledRef = useRef(keyboardShortcutsEnabled);
+  const onKeyboardShortcutRef = useRef(onKeyboardShortcut);
   const onWakeRef = useRef(onWake);
 
   useEffect(() => {
@@ -39,6 +43,10 @@ const useWakePlayerFromIframe = ({
   useEffect(() => {
     keyboardShortcutsEnabledRef.current = keyboardShortcutsEnabled;
   }, [keyboardShortcutsEnabled]);
+
+  useEffect(() => {
+    onKeyboardShortcutRef.current = onKeyboardShortcut;
+  }, [onKeyboardShortcut]);
 
   useEffect(() => {
     onWakeRef.current = onWake;
@@ -105,7 +113,7 @@ const useWakePlayerFromIframe = ({
           return;
         }
 
-        restorePlayerControls();
+        onKeyboardShortcutRef.current?.();
 
         const hostWindow = sectionElement.ownerDocument.defaultView;
 

--- a/src/components/Slide/utils/playerNavigationContext.test.ts
+++ b/src/components/Slide/utils/playerNavigationContext.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  shouldWakePlayerControlsAfterNavigation,
+  suppressPlayerControlsWakeAfterNavigation,
+} from "./playerNavigationContext";
+
+describe("playerNavigationContext", () => {
+  it("wakes player controls by default", () => {
+    expect(shouldWakePlayerControlsAfterNavigation()).toBe(true);
+    expect(shouldWakePlayerControlsAfterNavigation({})).toBe(true);
+  });
+
+  it("does not wake player controls when navigation disables it", () => {
+    expect(
+      shouldWakePlayerControlsAfterNavigation({ shouldWakeControls: false })
+    ).toBe(false);
+  });
+
+  it("preserves navigation context while suppressing player controls wake", () => {
+    const context = suppressPlayerControlsWakeAfterNavigation({
+      shouldContinuePlayback: true,
+    });
+
+    expect(context).toEqual({
+      shouldContinuePlayback: true,
+      shouldWakeControls: false,
+    });
+    expect(shouldWakePlayerControlsAfterNavigation(context)).toBe(false);
+  });
+});

--- a/src/components/Slide/utils/playerNavigationContext.ts
+++ b/src/components/Slide/utils/playerNavigationContext.ts
@@ -1,0 +1,16 @@
+export interface PlayerControlsWakeNavigationContext {
+  shouldWakeControls?: boolean;
+}
+
+export const shouldWakePlayerControlsAfterNavigation = (
+  context?: PlayerControlsWakeNavigationContext
+) => context?.shouldWakeControls !== false;
+
+export const suppressPlayerControlsWakeAfterNavigation = <
+  Context extends object,
+>(
+  context: Context
+): Context & { shouldWakeControls: false } => ({
+  ...context,
+  shouldWakeControls: false,
+});


### PR DESCRIPTION
## Summary
- add a navigation wake-control flag so keyboard previous/next shortcuts do not reveal hidden slide controls
- keep click/tap and control-button interactions waking the controls
- split iframe wake handling so iframe keyboard shortcuts activate and forward without restoring controls

## Verification
- pnpm exec vitest run --project unit src/components/Slide/utils/playerKeyboardShortcuts.test.ts src/components/Slide/utils/playerNavigationContext.test.ts
- pnpm exec prettier --check src/components/Slide/Player.tsx src/components/Slide/Slide.tsx src/components/Slide/useWakePlayerFromIframe.ts src/components/Slide/utils/playerNavigationContext.ts src/components/Slide/utils/playerNavigationContext.test.ts
- git diff --check
- Storybook manual check: default Slide shortcut stays hidden, click wakes controls, iframe shortcut stays hidden

## Known existing issue
- pnpm exec tsc -p tsconfig.json --pretty false still fails on existing repo-wide type issues in ContentRender, stories, diff-utils, and textarea ref typing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Granular control over whether player controls appear during slide navigation, so some navigation actions keep controls hidden.
  * Keyboard-driven navigation now consistently respects the controls-visibility rules, avoiding unexpected control wake-ups.

* **Tests**
  * Added tests covering player controls visibility behavior after navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->