### PR TITLE
fix: prioritize outer syntax highlight blocks

### DIFF
--- a/src/components/MarkdownFlowEditor/plugins/SyntaxHighlighter.test.ts
+++ b/src/components/MarkdownFlowEditor/plugins/SyntaxHighlighter.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { collectSyntaxHighlightRanges } from "./SyntaxHighlighter";
+
+function rangeTextsByClass(docText: string, className: string) {
+  return collectSyntaxHighlightRanges(docText)
+    .filter((range) => range.className === className)
+    .map((range) => docText.slice(range.from, range.to));
+}
+
+describe("collectSyntaxHighlightRanges", () => {
+  it("uses a multiline fixed output block as the outer highlight", () => {
+    const docText = [
+      "!===",
+      "Fixed output",
+      "<!--- ignored comment --->",
+      "!===",
+    ].join("\n");
+
+    const fixedTexts = rangeTextsByClass(docText, "syntax-fixed");
+    const commentTexts = rangeTextsByClass(docText, "syntax-comment");
+
+    expect(fixedTexts).toEqual([docText]);
+    expect(commentTexts).toEqual([]);
+  });
+
+  it("uses an HTML comment as the outer highlight", () => {
+    const docText = [
+      "<!---",
+      "!===",
+      "Ignored fixed output",
+      "!===",
+      "--->",
+    ].join("\n");
+
+    const fixedTexts = rangeTextsByClass(docText, "syntax-fixed");
+    const commentTexts = rangeTextsByClass(docText, "syntax-comment");
+
+    expect(commentTexts).toEqual([docText]);
+    expect(fixedTexts).toEqual([]);
+  });
+
+  it("keeps standalone comments and fixed output blocks highlighted", () => {
+    const docText = [
+      "<!--- note --->",
+      "",
+      "!===",
+      "Fixed output",
+      "!===",
+    ].join("\n");
+
+    const fixedTexts = rangeTextsByClass(docText, "syntax-fixed");
+    const commentTexts = rangeTextsByClass(docText, "syntax-comment");
+
+    expect(commentTexts).toEqual(["<!--- note --->"]);
+    expect(fixedTexts).toEqual(["!===" + "\nFixed output\n" + "!==="]);
+  });
+
+  it("keeps syntax after an outer block highlighted", () => {
+    const docText = [
+      "!===",
+      "<!--- ignored comment --->",
+      "!===",
+      "{{user_name}} ?[%{{choice}}Yes|No]",
+    ].join("\n");
+
+    const variableTexts = rangeTextsByClass(docText, "syntax-variable");
+    const keywordTexts = rangeTextsByClass(docText, "syntax-keyword");
+    const commentTexts = rangeTextsByClass(docText, "syntax-comment");
+
+    expect(commentTexts).toEqual([]);
+    expect(variableTexts).toEqual(["{{user_name}}", "{{choice}}"]);
+    expect(keywordTexts).toContain("?");
+    expect(keywordTexts).toContain("|");
+  });
+
+  it("uses single-line fixed output as the outer highlight", () => {
+    const docText = "=== <!--- ignored comment ---> ===";
+
+    const fixedTexts = rangeTextsByClass(docText, "syntax-fixed");
+    const commentTexts = rangeTextsByClass(docText, "syntax-comment");
+
+    expect(fixedTexts).toEqual([docText]);
+    expect(commentTexts).toEqual([]);
+  });
+});

--- a/src/components/MarkdownFlowEditor/plugins/SyntaxHighlighter.test.ts
+++ b/src/components/MarkdownFlowEditor/plugins/SyntaxHighlighter.test.ts
@@ -83,4 +83,14 @@ describe("collectSyntaxHighlightRanges", () => {
     expect(fixedTexts).toEqual([docText]);
     expect(commentTexts).toEqual([]);
   });
+
+  it("ignores fixed output markers inside inner comments", () => {
+    const docText = "=== <!--- ignored === marker ---> ===";
+
+    const fixedTexts = rangeTextsByClass(docText, "syntax-fixed");
+    const commentTexts = rangeTextsByClass(docText, "syntax-comment");
+
+    expect(fixedTexts).toEqual([docText]);
+    expect(commentTexts).toEqual([]);
+  });
 });

--- a/src/components/MarkdownFlowEditor/plugins/SyntaxHighlighter.ts
+++ b/src/components/MarkdownFlowEditor/plugins/SyntaxHighlighter.ts
@@ -10,7 +10,6 @@ import { createVariableExpressionRegexp } from "../utils";
 
 const broadVariableRegex = /\{\{.*?\}\}/g;
 const commentRegex = /<!--[\s\S]*?-->/g;
-const fixedOutputRegex = /===.*?===/g;
 const controlBlockRegex = /\?\[(.*?)\]/g;
 
 export interface SyntaxHighlightRange {
@@ -55,24 +54,48 @@ function collectMultilineFixedOutputRanges(
 }
 
 function collectSingleLineFixedOutputRanges(
-  docText: string
+  docText: string,
+  commentRanges: SyntaxHighlightRange[]
 ): SyntaxHighlightRange[] {
   const ranges: SyntaxHighlightRange[] = [];
-  let match;
 
-  fixedOutputRegex.lastIndex = 0;
-  while ((match = fixedOutputRegex.exec(docText)) !== null) {
-    const startIndex = match.index;
-    const isNegated = startIndex > 0 && docText[startIndex - 1] === "!";
-    if (isNegated) {
-      continue;
+  const isInsideComment = (index: number) =>
+    commentRanges.some((range) => index >= range.from && index < range.to);
+
+  let lineStart = 0;
+  while (lineStart <= docText.length) {
+    const newlineIndex = docText.indexOf("\n", lineStart);
+    const lineEnd = newlineIndex === -1 ? docText.length : newlineIndex;
+    const markerPositions: number[] = [];
+    let searchFrom = lineStart;
+
+    while (searchFrom < lineEnd) {
+      const markerIndex = docText.indexOf("===", searchFrom);
+      if (markerIndex === -1 || markerIndex >= lineEnd) {
+        break;
+      }
+
+      const isNegated = markerIndex > 0 && docText[markerIndex - 1] === "!";
+      if (!isNegated && !isInsideComment(markerIndex)) {
+        markerPositions.push(markerIndex);
+      }
+
+      searchFrom = markerIndex + 3;
     }
 
-    ranges.push({
-      from: startIndex,
-      to: startIndex + match[0].length,
-      className: "syntax-fixed",
-    });
+    for (let i = 0; i + 1 < markerPositions.length; i += 2) {
+      ranges.push({
+        from: markerPositions[i],
+        to: markerPositions[i + 1] + 3,
+        className: "syntax-fixed",
+      });
+    }
+
+    if (newlineIndex === -1) {
+      break;
+    }
+
+    lineStart = newlineIndex + 1;
   }
 
   return ranges;
@@ -103,10 +126,11 @@ function collectCommentRanges(docText: string): SyntaxHighlightRange[] {
 export function collectOuterBlockRanges(
   docText: string
 ): SyntaxHighlightRange[] {
+  const commentRanges = collectCommentRanges(docText);
   const blockRanges = [
     ...collectMultilineFixedOutputRanges(docText),
-    ...collectSingleLineFixedOutputRanges(docText),
-    ...collectCommentRanges(docText),
+    ...collectSingleLineFixedOutputRanges(docText, commentRanges),
+    ...commentRanges,
   ].sort((a, b) => {
     if (a.from !== b.from) return a.from - b.from;
     return b.to - a.to;
@@ -139,7 +163,6 @@ export function collectSyntaxHighlightRanges(
   const occupied: { from: number; to: number }[] = [];
 
   commentRegex.lastIndex = 0;
-  fixedOutputRegex.lastIndex = 0;
   controlBlockRegex.lastIndex = 0;
 
   // Prevent overlapping decorations so styling stays deterministic

--- a/src/components/MarkdownFlowEditor/plugins/SyntaxHighlighter.ts
+++ b/src/components/MarkdownFlowEditor/plugins/SyntaxHighlighter.ts
@@ -13,11 +13,128 @@ const commentRegex = /<!--[\s\S]*?-->/g;
 const fixedOutputRegex = /===.*?===/g;
 const controlBlockRegex = /\?\[(.*?)\]/g;
 
-function buildDecorations(view: EditorView): DecorationSet {
-  const builder = new RangeSetBuilder<Decoration>();
-  const docText = view.state.doc.toString();
+export interface SyntaxHighlightRange {
+  from: number;
+  to: number;
+  className: string;
+}
 
-  const matches: { from: number; to: number; className: string }[] = [];
+function collectMultilineFixedOutputRanges(
+  docText: string
+): SyntaxHighlightRange[] {
+  const ranges: SyntaxHighlightRange[] = [];
+  let pendingStart: number | null = null;
+  let lineStart = 0;
+
+  while (lineStart <= docText.length) {
+    const newlineIndex = docText.indexOf("\n", lineStart);
+    const lineEnd = newlineIndex === -1 ? docText.length : newlineIndex;
+    const lineText = docText.slice(lineStart, lineEnd);
+
+    if (lineText.trim() === "!===") {
+      if (pendingStart === null) {
+        pendingStart = lineStart;
+      } else {
+        ranges.push({
+          from: pendingStart,
+          to: lineEnd,
+          className: "syntax-fixed",
+        });
+        pendingStart = null;
+      }
+    }
+
+    if (newlineIndex === -1) {
+      break;
+    }
+
+    lineStart = newlineIndex + 1;
+  }
+
+  return ranges;
+}
+
+function collectSingleLineFixedOutputRanges(
+  docText: string
+): SyntaxHighlightRange[] {
+  const ranges: SyntaxHighlightRange[] = [];
+  let match;
+
+  fixedOutputRegex.lastIndex = 0;
+  while ((match = fixedOutputRegex.exec(docText)) !== null) {
+    const startIndex = match.index;
+    const isNegated = startIndex > 0 && docText[startIndex - 1] === "!";
+    if (isNegated) {
+      continue;
+    }
+
+    ranges.push({
+      from: startIndex,
+      to: startIndex + match[0].length,
+      className: "syntax-fixed",
+    });
+  }
+
+  return ranges;
+}
+
+function collectCommentRanges(docText: string): SyntaxHighlightRange[] {
+  const ranges: SyntaxHighlightRange[] = [];
+  let match;
+
+  commentRegex.lastIndex = 0;
+  while ((match = commentRegex.exec(docText)) !== null) {
+    ranges.push({
+      from: match.index,
+      to: match.index + match[0].length,
+      className: "syntax-comment",
+    });
+  }
+
+  return ranges;
+}
+
+function rangesOverlap(
+  first: SyntaxHighlightRange,
+  second: SyntaxHighlightRange
+) {
+  return !(first.to <= second.from || first.from >= second.to);
+}
+
+export function collectOuterBlockRanges(
+  docText: string
+): SyntaxHighlightRange[] {
+  const blockRanges = [
+    ...collectMultilineFixedOutputRanges(docText),
+    ...collectSingleLineFixedOutputRanges(docText),
+    ...collectCommentRanges(docText),
+  ].sort((a, b) => {
+    if (a.from !== b.from) return a.from - b.from;
+    return b.to - a.to;
+  });
+
+  const outerRanges: SyntaxHighlightRange[] = [];
+
+  for (const range of blockRanges) {
+    const isNestedOrOverlapping = outerRanges.some((outerRange) => {
+      const startsInsideOuter =
+        range.from >= outerRange.from && range.from < outerRange.to;
+      return startsInsideOuter || rangesOverlap(range, outerRange);
+    });
+
+    if (!isNestedOrOverlapping) {
+      outerRanges.push(range);
+    }
+  }
+
+  return outerRanges;
+}
+
+export function collectSyntaxHighlightRanges(
+  docText: string,
+  isCursorInside: (from: number, to: number) => boolean = () => false
+): SyntaxHighlightRange[] {
+  const matches: SyntaxHighlightRange[] = [];
   const occupied: { from: number; to: number }[] = [];
 
   commentRegex.lastIndex = 0;
@@ -27,12 +144,6 @@ function buildDecorations(view: EditorView): DecorationSet {
   // Prevent overlapping decorations so styling stays deterministic
   const isOverlapping = (from: number, to: number) =>
     occupied.some((range) => !(to <= range.from || from >= range.to));
-
-  const isCursorInside = (from: number, to: number) => {
-    return view.state.selection.ranges.some((range) => {
-      return range.from >= from && range.to <= to;
-    });
-  };
 
   const addMatch = (from: number, to: number, className: string) => {
     if (from >= to) return false;
@@ -55,41 +166,14 @@ function buildDecorations(view: EditorView): DecorationSet {
     };
   };
 
-  // 1. Comments
   let match;
-  while ((match = commentRegex.exec(docText)) !== null) {
-    addMatch(match.index, match.index + match[0].length, "syntax-comment");
+
+  // 1. Outer block ranges win over any syntax inside them.
+  for (const range of collectOuterBlockRanges(docText)) {
+    addMatch(range.from, range.to, range.className);
   }
 
-  // 2. Fixed Output (Multiline) - only when both markers are alone on their lines
-  const lineCount = view.state.doc.lines;
-  let pendingStart: { from: number; line: number } | null = null;
-  for (let i = 1; i <= lineCount; i++) {
-    const lineInfo = view.state.doc.line(i);
-    const trimmed = lineInfo.text.trim();
-    if (trimmed === "!===") {
-      if (!pendingStart) {
-        pendingStart = { from: lineInfo.from, line: i };
-        continue;
-      }
-      const startFrom = pendingStart.from;
-      const endTo = lineInfo.to;
-      addMatch(startFrom, endTo, "syntax-fixed");
-      pendingStart = null;
-    }
-  }
-
-  // 3. Fixed Output (Single line, skip "!===...!===")
-  while ((match = fixedOutputRegex.exec(docText)) !== null) {
-    const startIndex = match.index;
-    const isNegated = startIndex > 0 && docText[startIndex - 1] === "!";
-    if (isNegated) {
-      continue;
-    }
-    addMatch(startIndex, startIndex + match[0].length, "syntax-fixed");
-  }
-
-  // 4. Control Blocks
+  // 2. Control Blocks
   broadVariableRegex.lastIndex = 0;
   while ((match = controlBlockRegex.exec(docText)) !== null) {
     const fullStart = match.index;
@@ -246,7 +330,7 @@ function buildDecorations(view: EditorView): DecorationSet {
     }
   }
 
-  // 5. Variables (only if not already decorated; invalid ones stay default outside control blocks)
+  // 3. Variables (only if not already decorated; invalid ones stay default outside control blocks)
   broadVariableRegex.lastIndex = 0;
   while ((match = broadVariableRegex.exec(docText)) !== null) {
     const text = match[0];
@@ -267,6 +351,18 @@ function buildDecorations(view: EditorView): DecorationSet {
   matches.sort((a, b) => {
     if (a.from !== b.from) return a.from - b.from;
     return b.to - a.to;
+  });
+
+  return matches;
+}
+
+function buildDecorations(view: EditorView): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>();
+  const docText = view.state.doc.toString();
+  const matches = collectSyntaxHighlightRanges(docText, (from, to) => {
+    return view.state.selection.ranges.some((range) => {
+      return range.from >= from && range.to <= to;
+    });
   });
 
   for (const m of matches) {

--- a/src/components/MarkdownFlowEditor/plugins/SyntaxHighlighter.ts
+++ b/src/components/MarkdownFlowEditor/plugins/SyntaxHighlighter.ts
@@ -58,29 +58,41 @@ function collectSingleLineFixedOutputRanges(
   commentRanges: SyntaxHighlightRange[]
 ): SyntaxHighlightRange[] {
   const ranges: SyntaxHighlightRange[] = [];
+  let commentIndex = 0;
 
-  const isInsideComment = (index: number) =>
-    commentRanges.some((range) => index >= range.from && index < range.to);
+  const isInsideComment = (index: number) => {
+    while (
+      commentIndex < commentRanges.length &&
+      commentRanges[commentIndex].to <= index
+    ) {
+      commentIndex++;
+    }
+
+    const range = commentRanges[commentIndex];
+    return !!range && index >= range.from && index < range.to;
+  };
 
   let lineStart = 0;
   while (lineStart <= docText.length) {
     const newlineIndex = docText.indexOf("\n", lineStart);
     const lineEnd = newlineIndex === -1 ? docText.length : newlineIndex;
+    const lineText = docText.slice(lineStart, lineEnd);
     const markerPositions: number[] = [];
-    let searchFrom = lineStart;
+    let searchFrom = 0;
 
-    while (searchFrom < lineEnd) {
-      const markerIndex = docText.indexOf("===", searchFrom);
-      if (markerIndex === -1 || markerIndex >= lineEnd) {
+    while (searchFrom < lineText.length) {
+      const markerOffset = lineText.indexOf("===", searchFrom);
+      if (markerOffset === -1) {
         break;
       }
 
+      const markerIndex = lineStart + markerOffset;
       const isNegated = markerIndex > 0 && docText[markerIndex - 1] === "!";
       if (!isNegated && !isInsideComment(markerIndex)) {
         markerPositions.push(markerIndex);
       }
 
-      searchFrom = markerIndex + 3;
+      searchFrom = markerOffset + 3;
     }
 
     for (let i = 0; i + 1 < markerPositions.length; i += 2) {
@@ -162,7 +174,6 @@ export function collectSyntaxHighlightRanges(
   const matches: SyntaxHighlightRange[] = [];
   const occupied: { from: number; to: number }[] = [];
 
-  commentRegex.lastIndex = 0;
   controlBlockRegex.lastIndex = 0;
 
   // Prevent overlapping decorations so styling stays deterministic
@@ -198,7 +209,6 @@ export function collectSyntaxHighlightRanges(
   }
 
   // 2. Control Blocks
-  broadVariableRegex.lastIndex = 0;
   while ((match = controlBlockRegex.exec(docText)) !== null) {
     const fullStart = match.index;
     const fullEnd = match.index + match[0].length;

--- a/src/components/MarkdownFlowEditor/plugins/SyntaxHighlighter.ts
+++ b/src/components/MarkdownFlowEditor/plugins/SyntaxHighlighter.ts
@@ -94,13 +94,12 @@ function collectCommentRanges(docText: string): SyntaxHighlightRange[] {
   return ranges;
 }
 
-function rangesOverlap(
-  first: SyntaxHighlightRange,
-  second: SyntaxHighlightRange
-) {
-  return !(first.to <= second.from || first.from >= second.to);
-}
-
+/**
+ * Collects non-overlapping fixed-output and comment wrapper ranges.
+ *
+ * @param docText - Document text to scan.
+ * @returns Outer syntax highlight ranges sorted by document position.
+ */
 export function collectOuterBlockRanges(
   docText: string
 ): SyntaxHighlightRange[] {
@@ -116,13 +115,8 @@ export function collectOuterBlockRanges(
   const outerRanges: SyntaxHighlightRange[] = [];
 
   for (const range of blockRanges) {
-    const isNestedOrOverlapping = outerRanges.some((outerRange) => {
-      const startsInsideOuter =
-        range.from >= outerRange.from && range.from < outerRange.to;
-      return startsInsideOuter || rangesOverlap(range, outerRange);
-    });
-
-    if (!isNestedOrOverlapping) {
+    const lastOuter = outerRanges[outerRanges.length - 1];
+    if (!lastOuter || range.from >= lastOuter.to) {
       outerRanges.push(range);
     }
   }
@@ -130,6 +124,13 @@ export function collectOuterBlockRanges(
   return outerRanges;
 }
 
+/**
+ * Collects all custom syntax highlight ranges for editor decorations.
+ *
+ * @param docText - Document text to scan.
+ * @param isCursorInside - Returns true when the current cursor is inside a range.
+ * @returns Non-overlapping syntax highlight ranges sorted by document position.
+ */
 export function collectSyntaxHighlightRanges(
   docText: string,
   isCursorInside: (from: number, to: number) => boolean = () => false


### PR DESCRIPTION
## Summary
- Prioritize outer syntax highlight wrappers before decorating nested syntax.
- Keep `!=== ... !===` fixed-output blocks and `<!-- ... -->` comments from highlighting inner wrapper syntax.
- Add focused unit coverage for fixed-output/comment nesting and syntax after outer blocks.

## Root Cause
The custom CodeMirror decoration pass decorated comments before fixed-output blocks and rejected overlapping ranges. A comment inside a fixed-output block could occupy part of the range first, causing the outer fixed-output highlight to be skipped.

## Validation
- `npm test` passed; this repo script currently prints `No tests specified`.
- `pnpm exec vitest --project unit src/components/MarkdownFlowEditor/plugins/SyntaxHighlighter.test.ts` passed, 5 tests.
- `pnpm exec vitest --project unit` passed, 21 files / 100 tests.
- `pnpm exec prettier --check src/components/MarkdownFlowEditor/plugins/SyntaxHighlighter.ts src/components/MarkdownFlowEditor/plugins/SyntaxHighlighter.test.ts` passed.
- `git diff --check` passed.

## Notes
- `npm run lint` still fails on unrelated existing formatting issues in Slide/other files, not in the files changed here.
- `npm run build` exited 0, but `vite:dts` still prints existing unrelated type errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite validating syntax highlighting for fixed output blocks and HTML comments in the Markdown Flow Editor.

* **Refactor**
  * Improved syntax highlighting pipeline to better handle precedence of outer blocks and comment regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->