### PR TITLE
ci: switch manual npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-manual.yml
+++ b/.github/workflows/publish-manual.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write          # allow pushing the version-bump commit back to the branch
+      id-token: write          # OIDC: authenticate to npm via Trusted Publishing
 
     steps:
       # Strategy A: never publish from the protected default branch.
@@ -58,17 +59,12 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
 
+      # Trusted Publishing (OIDC) requires npm >= 11.5.1; node 20 ships an older npm.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
-
-      - name: Verify npm auth token
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          if ! npm whoami; then
-            echo "::error::NPM_TOKEN is missing or invalid. Generate a new npm Automation token (npmjs.com -> Access Tokens) and update the NPM_TOKEN repository secret."
-            exit 1
-          fi
 
       - name: Validate version and compute final version
         id: resolve
@@ -149,9 +145,11 @@ jobs:
       - name: Build
         run: npm run build
 
+      # No token: npm authenticates via OIDC Trusted Publishing (provenance is
+      # attached automatically). Requires a trusted publisher configured on npm
+      # for this repo + workflow file.
       - name: Publish to npm
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           DIST_TAG: ${{ steps.resolve.outputs.dist_tag }}
         run: npm publish --tag "$DIST_TAG"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -493,11 +493,13 @@ GitHub Action (`.github/workflows/publish-manual.yml`), so no local
 `npm publish` (and no interactive 2FA/OTP) is needed. The old push-on-`main`
 `publish.yml` is disabled (kept as `publish.yml.bk`).
 
-**Prerequisite — `NPM_TOKEN` secret**: the workflow authenticates with an npm
-**Automation** token (Automation tokens bypass 2FA in CI). It is read from the
-`NPM_TOKEN` repository secret. The workflow runs `npm whoami` first and fails
-early with a clear message if the token is missing or expired — regenerate the
-token and update the secret if that happens.
+**Prerequisite — npm Trusted Publishing (OIDC)**: the workflow authenticates to
+npm with no token, via GitHub OIDC. A one-time setup is required on npm: open
+the package page → **Settings → Trusted Publisher → GitHub Actions** and register
+this repository with workflow filename `publish-manual.yml`. The workflow
+declares `id-token: write` and upgrades npm to a version that supports trusted
+publishing; published packages get provenance automatically. No `NPM_TOKEN`
+secret is needed (tokens expire and can leak — OIDC avoids both).
 
 **Two package types** (enter the clean base version, e.g. `0.1.128`):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -497,8 +497,9 @@ GitHub Action (`.github/workflows/publish-manual.yml`), so no local
 npm with no token, via GitHub OIDC. A one-time setup is required on npm: open
 the package page → **Settings → Trusted Publisher → GitHub Actions** and register
 this repository with workflow filename `publish-manual.yml`. The workflow
-declares `id-token: write` and upgrades npm to a version that supports trusted
-publishing; published packages get provenance automatically. No `NPM_TOKEN`
+declares `id-token: write` and `contents: write` permissions and upgrades npm
+to a version that supports trusted publishing; published packages get provenance
+automatically. No `NPM_TOKEN`
 secret is needed (tokens expire and can leak — OIDC avoids both).
 
 **Two package types** (enter the clean base version, e.g. `0.1.128`):


### PR DESCRIPTION
## What

Switches the **Publish (manual)** workflow from a long-lived `NPM_TOKEN` to **npm Trusted Publishing (OIDC)**.

## Why

The 10-month-old `NPM_TOKEN` was expired (`npm whoami` returned E401). Rather than mint a new token that expires and can leak, authenticate via GitHub OIDC — npm's recommended approach for CI. No token, no expiry, no leak risk, and provenance is attached automatically.

## Changes

- `permissions: id-token: write` added.
- Removed the `NPM_TOKEN` env from publish and the `npm whoami` token check.
- Added `npm install -g npm@latest` (trusted publishing needs npm >= 11.5.1; node 20 ships an older npm).
- `npm publish` now runs without a token.
- AGENTS.md updated: documents the one-time npm trusted-publisher setup instead of the token prerequisite.

## Required one-time setup on npm

On the package page → **Settings → Trusted Publisher → GitHub Actions**, register:
- Organization/user: `ai-shifu`
- Repository: `markdown-flow-ui`
- Workflow filename: `publish-manual.yml`

After this merges to `main` and the publisher is configured, run the workflow from a feature branch to publish without any secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the manual release process to use a more secure publishing method.
  * Release publishing now includes automatic provenance and no longer depends on a stored npm auth token.
* **Documentation**
  * Clarified the release setup steps and prerequisites for maintaining the publishing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->