### PR TITLE
ci: install pnpm before build in manual publish

### DIFF
--- a/.github/workflows/publish-manual.yml
+++ b/.github/workflows/publish-manual.yml
@@ -63,6 +63,10 @@ jobs:
       - name: Upgrade npm for trusted publishing
         run: npm install -g npm@latest
 
+      # The build runs `pnpm exec tailwindcss` (build:css); pnpm is not preinstalled.
+      - name: Install pnpm
+        run: npm install -g pnpm
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
The manual publish workflow's Build step (`npm run build` → `vite build && pnpm run build:css`) failed with `pnpm: not found` (exit 127) — pnpm isn't preinstalled on the runner. Adds an `npm install -g pnpm` step before the build.

OIDC trusted publishing itself worked correctly in the failed run; it reached Build and only the pnpm dependency was missing.