### PR TITLE
ci: gate PRs to main on a release package.json version

### DIFF
--- a/.github/workflows/check-release-version.yml
+++ b/.github/workflows/check-release-version.yml
@@ -1,0 +1,47 @@
+name: Check release version
+
+# Gate for PRs into main: the "version" in package.json must be a RELEASE
+# version (X.Y.Z), never a pre-release/dev build (e.g. X.Y.Z-dev.N, X.Y.Z-rc.N).
+# dev builds are published from feature branches only and must not land on main.
+#
+# To actually block merges, add this check as a required status check in the
+# main ruleset.
+#
+# No `paths:` filter on purpose: required checks with path filters get stuck
+# "pending" on PRs that don't touch the filtered files.
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Ensure package.json version is a release version
+        run: |
+          node <<'NODE'
+          const fs = require("fs");
+          const version = JSON.parse(fs.readFileSync("package.json", "utf8")).version;
+          if (!version) {
+            console.error("::error::No 'version' field in package.json.");
+            process.exit(1);
+          }
+          // semver pre-release = anything after a hyphen (e.g. 0.1.128-dev.1)
+          if (version.includes("-")) {
+            console.error(
+              `::error::package.json version ${version} is a pre-release/dev build and ` +
+                "cannot be merged into main. Set a release version (X.Y.Z) first — dev " +
+                "builds (X.Y.Z-dev.N) are for feature-branch testing only.",
+            );
+            process.exit(1);
+          }
+          console.log(`OK: version ${version} is a release version.`);
+          NODE

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -526,6 +526,21 @@ not already taken) and auto-increments the `-dev.N` counter.
    `npm publish` → commits `chore: release <version>` back to the branch.
 4. Open a PR from the branch to `main`.
 
+#### Critical rule: PRs to `main` must carry a RELEASE version
+
+`dev` packages are throwaway test builds for feature branches only. Before opening
+(or merging) a PR into `main`, the `version` in `package.json` **must be a clean
+release version** (`X.Y.Z`), never `X.Y.Z-dev.N`. This is **enforced by CI**: the
+**Check release version** workflow (`.github/workflows/check-release-version.yml`)
+runs on every PR into `main` and fails if the version is a pre-release/dev build.
+(Add it as a required status check in the `main` ruleset to actually block merges.)
+
+> **Why this matters**: `markdown-flow-ui` is consumed by the `ai-shifu` project
+> (pinned in `src/cook-web/package.json`). A change here is usually made to be used
+> there, and ai-shifu refuses to merge a dev pin into its own `main` — so this
+> library's `main` must only ever carry release versions. dev builds stay on the
+> `dev` dist-tag / feature branches for cross-repo testing.
+
 ## Troubleshooting
 
 ### Common Issues and Solutions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -535,11 +535,9 @@ release version** (`X.Y.Z`), never `X.Y.Z-dev.N`. This is **enforced by CI**: th
 runs on every PR into `main` and fails if the version is a pre-release/dev build.
 (Add it as a required status check in the `main` ruleset to actually block merges.)
 
-> **Why this matters**: `markdown-flow-ui` is consumed by the `ai-shifu` project
-> (pinned in `src/cook-web/package.json`). A change here is usually made to be used
-> there, and ai-shifu refuses to merge a dev pin into its own `main` — so this
-> library's `main` must only ever carry release versions. dev builds stay on the
-> `dev` dist-tag / feature branches for cross-repo testing.
+> **Why this matters**: downstream projects install `markdown-flow-ui` from its
+> published releases, so `main` must only ever carry release versions. dev builds
+> stay on the `dev` dist-tag / feature branches for testing and never land on `main`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## What

Adds `.github/workflows/check-release-version.yml` — a `pull_request` check (target `main`) that fails when `package.json`'s `version` is a pre-release/dev build (e.g. `X.Y.Z-dev.N`).

## Why

`markdown-flow-ui` is consumed by `ai-shifu` (pinned in `src/cook-web/package.json`). dev builds (on the `dev` dist-tag) are for feature-branch testing only; `main` must always carry a clean release version.

## Behavior

- Runs on every PR into `main` (no `paths:` filter, so it never gets stuck pending as a required check).
- Pure node, no `npm ci`: reads `package.json` and blocks if `version` contains `-`. Verified: `0.1.128` passes, `0.1.128-dev.1`/`-rc.0` blocked.
- `permissions: contents: read` only.

## Follow-up

Add **Check release version** as a required status check in the `main` ruleset (alongside `lint`) to actually block merges.