### PR TITLE
ci: give the release-version check a unique job name

### DIFF
--- a/.github/workflows/check-release-version.yml
+++ b/.github/workflows/check-release-version.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read
 
 jobs:
-  check:
+  check-release-version:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository


### PR DESCRIPTION
Renames the `check-release-version` workflow's job from `check` to `check-release-version` so its status-check context is unique and can be added as a required status check on `main` (alongside `lint`). No behavior change.