### PR TITLE
chore: release markdown-flow-ui 0.1.128

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-flow-ui",
-  "version": "0.1.126",
+  "version": "0.1.128",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-flow-ui",
-      "version": "0.1.126",
+      "version": "0.1.128",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
       ]
     }
   },
-  "version": "0.1.126",
+  "version": "0.1.128",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
Published markdown-flow-ui@0.1.128 via Publish (manual): https://github.com/ai-shifu/markdown-flow-ui/actions/runs/28940599757. npm latest now points to 0.1.128. This PR backfills the release version into main.