### PR TITLE
fix: support subtitle jumps across slides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+/.pnpm-store
 /.pnp
 .pnp.*
 .yarn/*

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 node_modules
+.pnpm-store
 .next
 dist
 build

--- a/src/components/Slide/Player.tsx
+++ b/src/components/Slide/Player.tsx
@@ -139,6 +139,18 @@ const preloadAudioUrl = (url?: string) => {
   audioPreloadElementCache.set(url, audio);
 };
 
+const getSubtitleCueTrackSignature = (audioList: SlideAudioItem[]) =>
+  audioList
+    .map((audioItem) =>
+      (audioItem.element?.subtitle_cues ?? [])
+        .map(
+          (subtitleCue) =>
+            `${subtitleCue.start_ms}:${subtitleCue.end_ms}:${subtitleCue.segment_index}:${subtitleCue.position ?? ""}`
+        )
+        .join(",")
+    )
+    .join("|");
+
 export type PlayerProps = Omit<React.ComponentProps<"div">, "onEnded"> & {
   audioList?: SlideAudioItem[];
   currentAudioIndex?: number;
@@ -340,12 +352,13 @@ const Player = ({
     () => getSortedAudioSegments(currentAudio),
     [currentAudio]
   );
+  const subtitleCueTrackSignature = getSubtitleCueTrackSignature(audioList);
   const subtitleCueTracks = useMemo<SubtitleCueJumpTrack[]>(
     () =>
       audioList.map((audioItem) => ({
         subtitleCues: audioItem.element?.subtitle_cues ?? [],
       })),
-    [audioList]
+    [audioList, subtitleCueTrackSignature]
   );
   const customActionList = useMemo(
     () => toPlayerCustomActionList(customActions, customActionContext),

--- a/src/components/Slide/Player.tsx
+++ b/src/components/Slide/Player.tsx
@@ -204,6 +204,7 @@ export type PlayerProps = Omit<React.ComponentProps<"div">, "onEnded"> & {
     target: SlidePlayerSubtitleJumpTarget,
     context: SlidePlayerNavigationContext
   ) => boolean | void;
+  canJumpToSubtitleTarget?: (target: SlidePlayerSubtitleJumpTarget) => boolean;
   onFullscreen?: () => void;
   isFullscreen?: boolean;
   mobileViewMode?: MobileViewMode;
@@ -300,6 +301,7 @@ const Player = ({
   onPrev,
   onNext,
   onSubtitleJump,
+  canJumpToSubtitleTarget,
   onFullscreen,
   isFullscreen = false,
   mobileViewMode = DEFAULT_MOBILE_VIEW_MODE,
@@ -673,12 +675,24 @@ const Player = ({
         return null;
       }
 
+      if (target.audioIndex !== currentAudioIndex) {
+        if (!onSubtitleJump) {
+          return null;
+        }
+
+        if (canJumpToSubtitleTarget && !canJumpToSubtitleTarget(target)) {
+          return null;
+        }
+      }
+
       return target;
     },
     [
       audioList,
+      canJumpToSubtitleTarget,
       canSeekToAudioPlaybackTimeMs,
       currentAudioIndex,
+      onSubtitleJump,
       subtitleCueTracks,
     ]
   );

--- a/src/components/Slide/Player.tsx
+++ b/src/components/Slide/Player.tsx
@@ -156,10 +156,17 @@ export type PlayerProps = Omit<React.ComponentProps<"div">, "onEnded"> & {
   onSubtitleToggle?: () => void;
   onPrev?: (context: SlidePlayerNavigationContext) => void;
   onNext?: (context: SlidePlayerNavigationContext) => void;
+  /**
+   * Handles subtitle jumps that target a different audio track.
+   *
+   * Return `true` when the parent accepted the jump; return `false` or `void`
+   * when the player should treat the jump as rejected.
+   */
   onSubtitleJump?: (
     target: SlidePlayerSubtitleJumpTarget,
     context: SlidePlayerNavigationContext
   ) => boolean | void;
+  /** Returns whether a cross-audio subtitle jump target is currently reachable. */
   canJumpToSubtitleTarget?: (target: SlidePlayerSubtitleJumpTarget) => boolean;
   onFullscreen?: () => void;
   isFullscreen?: boolean;
@@ -187,6 +194,7 @@ export type PlayerProps = Omit<React.ComponentProps<"div">, "onEnded"> & {
    * ```
    */
   enableKeyboardShortcuts?: boolean;
+  /** Requests a subtitle seek after the parent moves to the target audio track. */
   subtitleSeekRequest?: SlidePlayerSubtitleSeekRequest | null;
   customActions?: SlidePlayerCustomActions;
   customActionContext?: SlidePlayerCustomActionContext;

--- a/src/components/Slide/Player.tsx
+++ b/src/components/Slide/Player.tsx
@@ -382,9 +382,10 @@ const Player = ({
   const currentAudio =
     currentAudioIndex >= 0 ? audioList[currentAudioIndex] : undefined;
   const currentAudioUrl = currentAudio?.audioUrl;
+  const currentAudioSegmentList = currentAudio?.audioSegments;
   const currentAudioSegments = useMemo(
     () => getSortedAudioSegments(currentAudio),
-    [currentAudio]
+    [currentAudio, currentAudioSegmentList]
   );
   let subtitleCueTracksCache = subtitleCueTracksCacheRef.current;
 

--- a/src/components/Slide/Player.tsx
+++ b/src/components/Slide/Player.tsx
@@ -383,9 +383,10 @@ const Player = ({
     currentAudioIndex >= 0 ? audioList[currentAudioIndex] : undefined;
   const currentAudioUrl = currentAudio?.audioUrl;
   const currentAudioSegmentList = currentAudio?.audioSegments;
+  const currentAudioSegmentCount = currentAudioSegmentList?.length ?? 0;
   const currentAudioSegments = useMemo(
     () => getSortedAudioSegments(currentAudio),
-    [currentAudio, currentAudioSegmentList]
+    [currentAudio, currentAudioSegmentCount, currentAudioSegmentList]
   );
   let subtitleCueTracksCache = subtitleCueTracksCacheRef.current;
 

--- a/src/components/Slide/Player.tsx
+++ b/src/components/Slide/Player.tsx
@@ -55,6 +55,7 @@ import {
   isPlaybackTimeCoveredBySegments,
   resolveSegmentSeekTarget,
 } from "./utils/segmentSeek";
+import { getSortedAudioSegments } from "./utils/audioSegments";
 import {
   getSubtitleCueJumpTarget,
   type SubtitleCueJumpDirection,
@@ -136,51 +137,6 @@ const preloadAudioUrl = (url?: string) => {
   audio.load();
 
   audioPreloadElementCache.set(url, audio);
-};
-
-type SlideAudioSegments = NonNullable<SlideAudioItem["audioSegments"]>;
-
-const sortedAudioSegmentsCache = new WeakMap<
-  SlideAudioSegments,
-  {
-    signature: string;
-    sortedSegments: SlideAudioSegments;
-  }
->();
-
-const getAudioSegmentsSignature = (audioSegments: SlideAudioSegments) =>
-  audioSegments
-    .map(
-      (segment) =>
-        `${segment.segment_index}:${Number(segment.duration_ms ?? 0)}:${segment.is_final ? "1" : "0"}`
-    )
-    .join("|");
-
-const getSortedAudioSegments = (audioItem?: SlideAudioItem) => {
-  const audioSegments = audioItem?.audioSegments;
-
-  if (!audioSegments) {
-    return [];
-  }
-
-  const signature = getAudioSegmentsSignature(audioSegments);
-  const cachedSegments = sortedAudioSegmentsCache.get(audioSegments);
-
-  if (cachedSegments?.signature === signature) {
-    return cachedSegments.sortedSegments;
-  }
-
-  const sortedSegments = [...audioSegments].sort(
-    (prevSegment, nextSegment) =>
-      prevSegment.segment_index - nextSegment.segment_index
-  );
-
-  sortedAudioSegmentsCache.set(audioSegments, {
-    signature,
-    sortedSegments,
-  });
-
-  return sortedSegments;
 };
 
 export type PlayerProps = Omit<React.ComponentProps<"div">, "onEnded"> & {

--- a/src/components/Slide/Player.tsx
+++ b/src/components/Slide/Player.tsx
@@ -56,8 +56,10 @@ import {
   resolveSegmentSeekTarget,
 } from "./utils/segmentSeek";
 import {
-  getSubtitleCueJumpTime,
+  getSubtitleCueJumpTarget,
   type SubtitleCueJumpDirection,
+  type SubtitleCueJumpTarget,
+  type SubtitleCueJumpTrack,
 } from "./utils/subtitleCue";
 import "./player.css";
 
@@ -109,6 +111,13 @@ export interface SlidePlayerNavigationContext {
   shouldWakeControls?: boolean;
 }
 
+export type SlidePlayerSubtitleJumpTarget = SubtitleCueJumpTarget;
+
+export interface SlidePlayerSubtitleSeekRequest
+  extends SlidePlayerSubtitleJumpTarget {
+  id: number | string;
+}
+
 const preloadAudioUrl = (url?: string) => {
   if (typeof window === "undefined" || !url) {
     return;
@@ -129,6 +138,12 @@ const preloadAudioUrl = (url?: string) => {
   audioPreloadElementCache.set(url, audio);
 };
 
+const getSortedAudioSegments = (audioItem?: SlideAudioItem) =>
+  [...(audioItem?.audioSegments ?? [])].sort(
+    (prevSegment, nextSegment) =>
+      prevSegment.segment_index - nextSegment.segment_index
+  );
+
 export type PlayerProps = Omit<React.ComponentProps<"div">, "onEnded"> & {
   audioList?: SlideAudioItem[];
   currentAudioIndex?: number;
@@ -146,6 +161,10 @@ export type PlayerProps = Omit<React.ComponentProps<"div">, "onEnded"> & {
   onSubtitleToggle?: () => void;
   onPrev?: (context: SlidePlayerNavigationContext) => void;
   onNext?: (context: SlidePlayerNavigationContext) => void;
+  onSubtitleJump?: (
+    target: SlidePlayerSubtitleJumpTarget,
+    context: SlidePlayerNavigationContext
+  ) => boolean | void;
   onFullscreen?: () => void;
   isFullscreen?: boolean;
   mobileViewMode?: MobileViewMode;
@@ -172,6 +191,7 @@ export type PlayerProps = Omit<React.ComponentProps<"div">, "onEnded"> & {
    * ```
    */
   enableKeyboardShortcuts?: boolean;
+  subtitleSeekRequest?: SlidePlayerSubtitleSeekRequest | null;
   customActions?: SlidePlayerCustomActions;
   customActionContext?: SlidePlayerCustomActionContext;
   texts?: SlidePlayerTexts;
@@ -240,6 +260,7 @@ const Player = ({
   onSubtitleToggle,
   onPrev,
   onNext,
+  onSubtitleJump,
   onFullscreen,
   isFullscreen = false,
   mobileViewMode = DEFAULT_MOBILE_VIEW_MODE,
@@ -255,6 +276,7 @@ const Player = ({
   nextDisabled = false,
   showControls = true,
   enableKeyboardShortcuts = true,
+  subtitleSeekRequest = null,
   customActions,
   customActionContext,
   texts,
@@ -292,6 +314,7 @@ const Player = ({
     (currentTimeMs: number) => void
   >(() => {});
   const lastSubtitleJumpAvailabilityTimeMsRef = useRef<number | null>(null);
+  const lastSubtitleSeekRequestIdRef = useRef<number | string | null>(null);
   const playbackAccessModeRef = useRef<
     "unknown" | "auto" | "manual" | "blocked"
   >("unknown");
@@ -309,16 +332,15 @@ const Player = ({
     currentAudioIndex >= 0 ? audioList[currentAudioIndex] : undefined;
   const currentAudioUrl = currentAudio?.audioUrl;
   const currentAudioSegments = useMemo(
-    () =>
-      [...(currentAudio?.audioSegments ?? [])].sort(
-        (prevSegment, nextSegment) =>
-          prevSegment.segment_index - nextSegment.segment_index
-      ),
-    [currentAudio?.audioSegments]
+    () => getSortedAudioSegments(currentAudio),
+    [currentAudio]
   );
-  const currentSubtitleCues = useMemo(
-    () => currentAudio?.element?.subtitle_cues ?? [],
-    [currentAudio?.element?.subtitle_cues]
+  const subtitleCueTracks = useMemo<SubtitleCueJumpTrack[]>(
+    () =>
+      audioList.map((audioItem) => ({
+        subtitleCues: audioItem.element?.subtitle_cues ?? [],
+      })),
+    [audioList]
   );
   const customActionList = useMemo(
     () => toPlayerCustomActionList(customActions, customActionContext),
@@ -575,36 +597,51 @@ const Player = ({
       );
   }, []);
 
-  const canSeekToPlaybackTimeMs = useCallback(
-    (timeMs: number) => {
-      if (!currentAudio || isPlaybackPaused) {
+  const canSeekToAudioPlaybackTimeMs = useCallback(
+    (audioItem: SlideAudioItem | undefined, timeMs: number) => {
+      if (!audioItem || isPlaybackPaused) {
         return false;
       }
 
-      if (currentAudioUrl) {
+      if (audioItem.audioUrl) {
         return true;
       }
 
-      return isPlaybackTimeCoveredBySegments(currentAudioSegments, timeMs);
+      return isPlaybackTimeCoveredBySegments(
+        getSortedAudioSegments(audioItem),
+        timeMs
+      );
     },
-    [currentAudio, currentAudioSegments, currentAudioUrl, isPlaybackPaused]
+    [isPlaybackPaused]
   );
 
-  const getSubtitleJumpTargetTimeMs = useCallback(
+  const getSubtitleJumpTarget = useCallback(
     (direction: SubtitleCueJumpDirection, currentTimeMs: number) => {
-      const targetTimeMs = getSubtitleCueJumpTime({
+      const target = getSubtitleCueJumpTarget({
+        currentAudioIndex,
         currentTimeMs,
         direction,
-        subtitleCues: currentSubtitleCues,
+        tracks: subtitleCueTracks,
       });
 
-      if (targetTimeMs === null || !canSeekToPlaybackTimeMs(targetTimeMs)) {
+      if (
+        !target ||
+        !canSeekToAudioPlaybackTimeMs(
+          audioList[target.audioIndex],
+          target.timeMs
+        )
+      ) {
         return null;
       }
 
-      return targetTimeMs;
+      return target;
     },
-    [canSeekToPlaybackTimeMs, currentSubtitleCues]
+    [
+      audioList,
+      canSeekToAudioPlaybackTimeMs,
+      currentAudioIndex,
+      subtitleCueTracks,
+    ]
   );
 
   const updateSubtitleJumpAvailability = useCallback(
@@ -626,10 +663,8 @@ const Player = ({
 
       const nextAvailability = {
         previous:
-          getSubtitleJumpTargetTimeMs("previous", normalizedCurrentTimeMs) !==
-          null,
-        next:
-          getSubtitleJumpTargetTimeMs("next", normalizedCurrentTimeMs) !== null,
+          getSubtitleJumpTarget("previous", normalizedCurrentTimeMs) !== null,
+        next: getSubtitleJumpTarget("next", normalizedCurrentTimeMs) !== null,
       };
 
       setSubtitleJumpAvailability((previousAvailability) => {
@@ -643,7 +678,7 @@ const Player = ({
         return nextAvailability;
       });
     },
-    [getSubtitleJumpTargetTimeMs]
+    [getSubtitleJumpTarget]
   );
 
   useEffect(() => {
@@ -976,20 +1011,32 @@ const Player = ({
 
   const jumpToSubtitleCue = useCallback(
     (direction: SubtitleCueJumpDirection) => {
-      const targetTimeMs = getSubtitleJumpTargetTimeMs(
+      const target = getSubtitleJumpTarget(
         direction,
         getCurrentPlaybackTimeMs()
       );
 
-      if (targetTimeMs === null) {
+      if (target === null) {
         return false;
       }
 
-      return seekToPlaybackTimeMs(targetTimeMs);
+      if (target.audioIndex === currentAudioIndex) {
+        return seekToPlaybackTimeMs(target.timeMs);
+      }
+
+      return Boolean(
+        onSubtitleJump?.(
+          target,
+          suppressPlayerControlsWakeAfterNavigation(getNavigationContext())
+        )
+      );
     },
     [
+      currentAudioIndex,
       getCurrentPlaybackTimeMs,
-      getSubtitleJumpTargetTimeMs,
+      getNavigationContext,
+      getSubtitleJumpTarget,
+      onSubtitleJump,
       seekToPlaybackTimeMs,
     ]
   );
@@ -1340,6 +1387,36 @@ const Player = ({
     tryPlayCurrentAudio,
     getWaitingSegmentSeekTime,
     updateLoading,
+  ]);
+
+  useEffect(() => {
+    if (!subtitleSeekRequest) {
+      return;
+    }
+
+    if (
+      subtitleSeekRequest.id === lastSubtitleSeekRequestIdRef.current ||
+      subtitleSeekRequest.audioIndex !== currentAudioIndex
+    ) {
+      return;
+    }
+
+    const targetAudio = audioList[subtitleSeekRequest.audioIndex];
+
+    if (
+      !canSeekToAudioPlaybackTimeMs(targetAudio, subtitleSeekRequest.timeMs)
+    ) {
+      return;
+    }
+
+    lastSubtitleSeekRequestIdRef.current = subtitleSeekRequest.id;
+    seekToPlaybackTimeMs(subtitleSeekRequest.timeMs);
+  }, [
+    audioList,
+    canSeekToAudioPlaybackTimeMs,
+    currentAudioIndex,
+    seekToPlaybackTimeMs,
+    subtitleSeekRequest,
   ]);
 
   useEffect(() => resetAudio, [resetAudio]);

--- a/src/components/Slide/Player.tsx
+++ b/src/components/Slide/Player.tsx
@@ -138,11 +138,50 @@ const preloadAudioUrl = (url?: string) => {
   audioPreloadElementCache.set(url, audio);
 };
 
-const getSortedAudioSegments = (audioItem?: SlideAudioItem) =>
-  [...(audioItem?.audioSegments ?? [])].sort(
+type SlideAudioSegments = NonNullable<SlideAudioItem["audioSegments"]>;
+
+const sortedAudioSegmentsCache = new WeakMap<
+  SlideAudioSegments,
+  {
+    signature: string;
+    sortedSegments: SlideAudioSegments;
+  }
+>();
+
+const getAudioSegmentsSignature = (audioSegments: SlideAudioSegments) =>
+  audioSegments
+    .map(
+      (segment) =>
+        `${segment.segment_index}:${Number(segment.duration_ms ?? 0)}:${segment.is_final ? "1" : "0"}`
+    )
+    .join("|");
+
+const getSortedAudioSegments = (audioItem?: SlideAudioItem) => {
+  const audioSegments = audioItem?.audioSegments;
+
+  if (!audioSegments) {
+    return [];
+  }
+
+  const signature = getAudioSegmentsSignature(audioSegments);
+  const cachedSegments = sortedAudioSegmentsCache.get(audioSegments);
+
+  if (cachedSegments?.signature === signature) {
+    return cachedSegments.sortedSegments;
+  }
+
+  const sortedSegments = [...audioSegments].sort(
     (prevSegment, nextSegment) =>
       prevSegment.segment_index - nextSegment.segment_index
   );
+
+  sortedAudioSegmentsCache.set(audioSegments, {
+    signature,
+    sortedSegments,
+  });
+
+  return sortedSegments;
+};
 
 export type PlayerProps = Omit<React.ComponentProps<"div">, "onEnded"> & {
   audioList?: SlideAudioItem[];

--- a/src/components/Slide/Player.tsx
+++ b/src/components/Slide/Player.tsx
@@ -27,6 +27,7 @@ import MobilePlayerSettingsSheet from "./MobilePlayerSettingsSheet";
 import { DEFAULT_SLIDE_PLAYER_TEXTS } from "./constants";
 import type { SlideAudioItem } from "./useSlide";
 import type {
+  ElementSubtitleCue,
   SlidePlayerCustomActionContext,
   SlidePlayerCustomActions,
 } from "./types";
@@ -139,17 +140,49 @@ const preloadAudioUrl = (url?: string) => {
   audioPreloadElementCache.set(url, audio);
 };
 
-const getSubtitleCueTrackSignature = (audioList: SlideAudioItem[]) =>
-  audioList
-    .map((audioItem) =>
-      (audioItem.element?.subtitle_cues ?? [])
-        .map(
-          (subtitleCue) =>
-            `${subtitleCue.start_ms}:${subtitleCue.end_ms}:${subtitleCue.segment_index}:${subtitleCue.position ?? ""}`
-        )
-        .join(",")
-    )
-    .join("|");
+type SubtitleCueList = ElementSubtitleCue[] | undefined;
+
+interface SubtitleCueTracksCache {
+  audioList: SlideAudioItem[];
+  subtitleCueLists: SubtitleCueList[];
+  subtitleCueLengths: number[];
+  tracks: SubtitleCueJumpTrack[];
+}
+
+const hasCurrentSubtitleCueTracksCache = (
+  audioList: SlideAudioItem[],
+  cache: SubtitleCueTracksCache | null
+): cache is SubtitleCueTracksCache =>
+  cache !== null &&
+  cache.audioList === audioList &&
+  cache.subtitleCueLists.length === audioList.length &&
+  audioList.every((audioItem, index) => {
+    const subtitleCues = audioItem.element?.subtitle_cues;
+
+    return (
+      cache.subtitleCueLists[index] === subtitleCues &&
+      cache.subtitleCueLengths[index] === (subtitleCues?.length ?? 0)
+    );
+  });
+
+const createSubtitleCueTracksCache = (
+  audioList: SlideAudioItem[]
+): SubtitleCueTracksCache => {
+  const subtitleCueLists = audioList.map(
+    (audioItem) => audioItem.element?.subtitle_cues
+  );
+
+  return {
+    audioList,
+    subtitleCueLists,
+    subtitleCueLengths: subtitleCueLists.map(
+      (subtitleCues) => subtitleCues?.length ?? 0
+    ),
+    tracks: subtitleCueLists.map((subtitleCues) => ({
+      subtitleCues: subtitleCues ?? [],
+    })),
+  };
+};
 
 export type PlayerProps = Omit<React.ComponentProps<"div">, "onEnded"> & {
   audioList?: SlideAudioItem[];
@@ -332,6 +365,7 @@ const Player = ({
   >(() => {});
   const lastSubtitleJumpAvailabilityTimeMsRef = useRef<number | null>(null);
   const lastSubtitleSeekRequestIdRef = useRef<number | string | null>(null);
+  const subtitleCueTracksCacheRef = useRef<SubtitleCueTracksCache | null>(null);
   const playbackAccessModeRef = useRef<
     "unknown" | "auto" | "manual" | "blocked"
   >("unknown");
@@ -352,14 +386,14 @@ const Player = ({
     () => getSortedAudioSegments(currentAudio),
     [currentAudio]
   );
-  const subtitleCueTrackSignature = getSubtitleCueTrackSignature(audioList);
-  const subtitleCueTracks = useMemo<SubtitleCueJumpTrack[]>(
-    () =>
-      audioList.map((audioItem) => ({
-        subtitleCues: audioItem.element?.subtitle_cues ?? [],
-      })),
-    [audioList, subtitleCueTrackSignature]
-  );
+  let subtitleCueTracksCache = subtitleCueTracksCacheRef.current;
+
+  if (!hasCurrentSubtitleCueTracksCache(audioList, subtitleCueTracksCache)) {
+    subtitleCueTracksCache = createSubtitleCueTracksCache(audioList);
+    subtitleCueTracksCacheRef.current = subtitleCueTracksCache;
+  }
+
+  const subtitleCueTracks = subtitleCueTracksCache.tracks;
   const customActionList = useMemo(
     () => toPlayerCustomActionList(customActions, customActionContext),
     [customActionContext, customActions]

--- a/src/components/Slide/Slide.tsx
+++ b/src/components/Slide/Slide.tsx
@@ -632,6 +632,7 @@ const Slide: React.FC<SlideProps> = ({
     setHasCompletedCurrentStepAudio(false);
     setHasCurrentAudioPlaybackStarted(false);
     setSubtitleSeekRequest(null);
+    pendingSubtitleJumpRef.current = null;
     setActiveInteractionElement(undefined);
     setIsInteractionOverlayOpen(false);
     setInteractionOverlaySubtitleOffset(0);
@@ -1453,13 +1454,13 @@ const Slide: React.FC<SlideProps> = ({
       }
 
       shouldScrollToBottomRef.current = true;
+      resetAudioSequence();
       pendingSubtitleJumpRef.current = {
         audioIndex: target.audioIndex,
         audioKey: targetAudioKey,
         slideIndex: targetSlideIndex,
         timeMs: target.timeMs,
       };
-      resetAudioSequence();
       goTo(targetSlideIndex);
 
       return true;

--- a/src/components/Slide/Slide.tsx
+++ b/src/components/Slide/Slide.tsx
@@ -31,6 +31,8 @@ import SubtitleOverlay from "./SubtitleOverlay";
 import type {
   PlayerProps,
   SlidePlayerNavigationContext,
+  SlidePlayerSubtitleJumpTarget,
+  SlidePlayerSubtitleSeekRequest,
   SlidePlayerTexts,
 } from "./Player";
 import type { SlidePlayerLoadingReason } from "./Player";
@@ -267,6 +269,13 @@ const Slide: React.FC<SlideProps> = ({
   const prevRenderElementKeysRef = useRef<string[]>([]);
   const shouldScrollToBottomRef = useRef(false);
   const pendingInteractionOverlayStepIndexRef = useRef<number | null>(null);
+  const pendingSubtitleJumpRef = useRef<{
+    audioIndex: number;
+    audioKey: string;
+    slideIndex: number;
+    timeMs: number;
+  } | null>(null);
+  const subtitleSeekRequestIdRef = useRef(0);
   const playbackResetKeyRef = useRef<string | null>(null);
   const appendedMarkerAdvanceStateRef = useRef({
     markerCount: 0,
@@ -279,6 +288,7 @@ const Slide: React.FC<SlideProps> = ({
     slideElementList,
     currentIndex,
     audioList,
+    audioSlideIndexes,
     currentAudioSequenceIndexes,
     currentStepHasSpeakableElement,
     currentInteractionElement,
@@ -286,6 +296,7 @@ const Slide: React.FC<SlideProps> = ({
     canGoNext,
     handlePrev: goPrev,
     handleNext: goNext,
+    handleGoTo: goTo,
   } = useSlide(elementList);
   const currentStepElement = useMemo(() => {
     if (currentIndex < 0) {
@@ -329,6 +340,8 @@ const Slide: React.FC<SlideProps> = ({
   const [isPlaybackRequested, setIsPlaybackRequested] = useState(true);
   const [isAutoAdvanceEnabled, setIsAutoAdvanceEnabled] = useState(true);
   const [currentAudioKey, setCurrentAudioKey] = useState<string | null>(null);
+  const [subtitleSeekRequest, setSubtitleSeekRequest] =
+    useState<SlidePlayerSubtitleSeekRequest | null>(null);
   const [isAudioLoadingVisible, setIsAudioLoadingVisible] = useState(false);
   const [audioLoadingReason, setAudioLoadingReason] =
     useState<SlideBufferingReason>(DEFAULT_BUFFERING_REASON);
@@ -618,6 +631,7 @@ const Slide: React.FC<SlideProps> = ({
     setAudioLoadingReason(DEFAULT_BUFFERING_REASON);
     setHasCompletedCurrentStepAudio(false);
     setHasCurrentAudioPlaybackStarted(false);
+    setSubtitleSeekRequest(null);
     setActiveInteractionElement(undefined);
     setIsInteractionOverlayOpen(false);
     setInteractionOverlaySubtitleOffset(0);
@@ -627,6 +641,17 @@ const Slide: React.FC<SlideProps> = ({
     clearInteractionOverlayOpenTimer,
     playbackTimeStore,
   ]);
+
+  const requestSubtitleCueSeek = useCallback(
+    (target: SlidePlayerSubtitleJumpTarget) => {
+      subtitleSeekRequestIdRef.current += 1;
+      setSubtitleSeekRequest({
+        ...target,
+        id: subtitleSeekRequestIdRef.current,
+      });
+    },
+    []
+  );
 
   const startCurrentAudioSequence = useCallback(() => {
     const nextAudioKey = currentAudioSequenceKeys[0];
@@ -953,6 +978,18 @@ const Slide: React.FC<SlideProps> = ({
       return;
     }
 
+    const pendingSubtitleJump = pendingSubtitleJumpRef.current;
+
+    if (pendingSubtitleJump?.slideIndex === currentIndex) {
+      pendingSubtitleJumpRef.current = null;
+      setCurrentAudioKey(pendingSubtitleJump.audioKey);
+      requestSubtitleCueSeek({
+        audioIndex: pendingSubtitleJump.audioIndex,
+        timeMs: pendingSubtitleJump.timeMs,
+      });
+      return;
+    }
+
     if (currentInteractionElement) {
       setActiveInteractionElement(currentInteractionElement);
     }
@@ -1018,6 +1055,7 @@ const Slide: React.FC<SlideProps> = ({
     shouldBlockPlaybackForInteraction,
     clearInteractionOverlayOpenTimer,
     resetAudioSequence,
+    requestSubtitleCueSeek,
     scheduleInteractionOverlayOpen,
     startCurrentAudioSequence,
     shouldPausePlaybackForCustomAction,
@@ -1381,6 +1419,62 @@ const Slide: React.FC<SlideProps> = ({
       behavior: "smooth",
     });
   }, []);
+
+  const handleSubtitleJump = useCallback(
+    (
+      target: SlidePlayerSubtitleJumpTarget,
+      context: SlidePlayerNavigationContext
+    ) => {
+      const targetAudio = audioList[target.audioIndex];
+      const targetAudioKey = targetAudio?.audioKey;
+      const targetSlideIndex = audioSlideIndexes[target.audioIndex];
+
+      if (!targetAudioKey || targetSlideIndex == null) {
+        return false;
+      }
+
+      syncPlaybackPreferenceBeforeNavigation(context);
+      pendingInteractionOverlayStepIndexRef.current = null;
+      setIsAudioLoadingVisible(false);
+      setHasCompletedCurrentStepAudio(false);
+      setHasCurrentAudioPlaybackStarted(false);
+
+      if (shouldWakePlayerControlsAfterNavigation(context)) {
+        setHasPlayerInteracted(true);
+        showPlayerControls(true);
+      }
+
+      if (targetSlideIndex === currentIndex) {
+        pendingSubtitleJumpRef.current = null;
+        resetAudioSequence();
+        setCurrentAudioKey(targetAudioKey);
+        requestSubtitleCueSeek(target);
+        return true;
+      }
+
+      shouldScrollToBottomRef.current = true;
+      pendingSubtitleJumpRef.current = {
+        audioIndex: target.audioIndex,
+        audioKey: targetAudioKey,
+        slideIndex: targetSlideIndex,
+        timeMs: target.timeMs,
+      };
+      resetAudioSequence();
+      goTo(targetSlideIndex);
+
+      return true;
+    },
+    [
+      audioList,
+      audioSlideIndexes,
+      currentIndex,
+      goTo,
+      requestSubtitleCueSeek,
+      resetAudioSequence,
+      showPlayerControls,
+      syncPlaybackPreferenceBeforeNavigation,
+    ]
+  );
 
   const handlePrev = useCallback(
     (context?: SlidePlayerNavigationContext) => {
@@ -1822,8 +1916,10 @@ const Slide: React.FC<SlideProps> = ({
               onInteractionToggle={handleInteractionToggle}
               onNext={handleNext}
               onPrev={handlePrev}
+              onSubtitleJump={handleSubtitleJump}
               prevDisabled={!canGoPrev}
               showControls={playerVisible}
+              subtitleSeekRequest={subtitleSeekRequest}
               texts={playerTexts}
               customActionContext={playerCustomActionContext}
               customActions={playerCustomActions}

--- a/src/components/Slide/Slide.tsx
+++ b/src/components/Slide/Slide.tsx
@@ -1001,6 +1001,7 @@ const Slide: React.FC<SlideProps> = ({
       if (
         !canReachSubtitleJumpTarget({
           currentIndex,
+          resolvedCurrentInteractionElement: activeInteractionElement,
           slideElementList,
           targetSlideIndex: pendingSubtitleJump.slideIndex,
         })
@@ -1066,9 +1067,11 @@ const Slide: React.FC<SlideProps> = ({
       clearAutoAdvanceTimer();
     };
   }, [
+    activeInteractionElement,
     canGoNext,
     clearAutoAdvanceTimer,
     currentElementList.length,
+    currentIndex,
     currentInteractionElement,
     currentAudioKey,
     currentPlaybackResetKey,
@@ -1084,6 +1087,7 @@ const Slide: React.FC<SlideProps> = ({
     resetAudioSequence,
     requestSubtitleCueSeek,
     scheduleInteractionOverlayOpen,
+    slideElementList,
     startCurrentAudioSequence,
     shouldPausePlaybackForCustomAction,
     shouldUseSilentStepAutoAdvanceToggle,
@@ -1451,10 +1455,16 @@ const Slide: React.FC<SlideProps> = ({
     (target: SlidePlayerSubtitleJumpTarget) =>
       canReachSubtitleJumpTarget({
         currentIndex,
+        resolvedCurrentInteractionElement: activeInteractionElement,
         slideElementList,
         targetSlideIndex: audioSlideIndexes[target.audioIndex],
       }),
-    [audioSlideIndexes, currentIndex, slideElementList]
+    [
+      activeInteractionElement,
+      audioSlideIndexes,
+      currentIndex,
+      slideElementList,
+    ]
   );
 
   const handleSubtitleJump = useCallback(

--- a/src/components/Slide/Slide.tsx
+++ b/src/components/Slide/Slide.tsx
@@ -51,6 +51,10 @@ import { shouldWakePlayerControlsAfterNavigation } from "./utils/playerNavigatio
 import { shouldAutoAdvanceIntoAppendedMarker } from "./utils/appendedMarkerAdvance";
 import { getPlaybackSequenceTransition } from "./utils/playbackSequence";
 import {
+  canReachSubtitleJumpTarget,
+  hasResolvedInteractionElement,
+} from "./utils/subtitleJumpNavigation";
+import {
   getPlayerCustomActionCount,
   resolvePlayerCustomActionElement,
 } from "./utils/playerCustomActions";
@@ -621,27 +625,36 @@ const Slide: React.FC<SlideProps> = ({
     autoAdvanceTimerRef.current = null;
   }, []);
 
-  const resetAudioSequence = useCallback(() => {
-    clearAutoAdvanceTimer();
-    clearInteractionAutoCloseTimer();
-    clearInteractionOverlayOpenTimer();
-    setCurrentAudioKey(null);
-    playbackTimeStore.reset();
-    setIsAudioLoadingVisible(false);
-    setAudioLoadingReason(DEFAULT_BUFFERING_REASON);
-    setHasCompletedCurrentStepAudio(false);
-    setHasCurrentAudioPlaybackStarted(false);
-    setSubtitleSeekRequest(null);
-    pendingSubtitleJumpRef.current = null;
-    setActiveInteractionElement(undefined);
-    setIsInteractionOverlayOpen(false);
-    setInteractionOverlaySubtitleOffset(0);
-  }, [
-    clearAutoAdvanceTimer,
-    clearInteractionAutoCloseTimer,
-    clearInteractionOverlayOpenTimer,
-    playbackTimeStore,
-  ]);
+  const resetAudioSequence = useCallback(
+    (
+      options: {
+        preservePendingSubtitleJump?: boolean;
+      } = {}
+    ) => {
+      clearAutoAdvanceTimer();
+      clearInteractionAutoCloseTimer();
+      clearInteractionOverlayOpenTimer();
+      setCurrentAudioKey(null);
+      playbackTimeStore.reset();
+      setIsAudioLoadingVisible(false);
+      setAudioLoadingReason(DEFAULT_BUFFERING_REASON);
+      setHasCompletedCurrentStepAudio(false);
+      setHasCurrentAudioPlaybackStarted(false);
+      setSubtitleSeekRequest(null);
+      if (!options.preservePendingSubtitleJump) {
+        pendingSubtitleJumpRef.current = null;
+      }
+      setActiveInteractionElement(undefined);
+      setIsInteractionOverlayOpen(false);
+      setInteractionOverlaySubtitleOffset(0);
+    },
+    [
+      clearAutoAdvanceTimer,
+      clearInteractionAutoCloseTimer,
+      clearInteractionOverlayOpenTimer,
+      playbackTimeStore,
+    ]
+  );
 
   const requestSubtitleCueSeek = useCallback(
     (target: SlidePlayerSubtitleJumpTarget) => {
@@ -740,8 +753,7 @@ const Slide: React.FC<SlideProps> = ({
   );
 
   const hasResolvedCurrentInteraction = Boolean(
-    currentInteractionElement?.readonly ||
-      currentInteractionElement?.user_input?.trim()
+    hasResolvedInteractionElement(currentInteractionElement)
   );
 
   const shouldBlockPlaybackForInteraction =
@@ -967,8 +979,14 @@ const Slide: React.FC<SlideProps> = ({
       currentStepHasSpeakableElement,
     });
 
+    const pendingSubtitleJump = pendingSubtitleJumpRef.current;
+    const shouldPreservePendingSubtitleJump =
+      pendingSubtitleJump?.slideIndex === currentIndex;
+
     if (hasPlaybackContextChanged) {
-      resetAudioSequence();
+      resetAudioSequence({
+        preservePendingSubtitleJump: shouldPreservePendingSubtitleJump,
+      });
     }
 
     if (currentElementList.length === 0 && !currentInteractionElement) {
@@ -979,16 +997,24 @@ const Slide: React.FC<SlideProps> = ({
       return;
     }
 
-    const pendingSubtitleJump = pendingSubtitleJumpRef.current;
-
     if (pendingSubtitleJump?.slideIndex === currentIndex) {
-      pendingSubtitleJumpRef.current = null;
-      setCurrentAudioKey(pendingSubtitleJump.audioKey);
-      requestSubtitleCueSeek({
-        audioIndex: pendingSubtitleJump.audioIndex,
-        timeMs: pendingSubtitleJump.timeMs,
-      });
-      return;
+      if (
+        !canReachSubtitleJumpTarget({
+          currentIndex,
+          slideElementList,
+          targetSlideIndex: pendingSubtitleJump.slideIndex,
+        })
+      ) {
+        // Keep the pending seek queued while the interaction overlay gates playback.
+      } else {
+        pendingSubtitleJumpRef.current = null;
+        setCurrentAudioKey(pendingSubtitleJump.audioKey);
+        requestSubtitleCueSeek({
+          audioIndex: pendingSubtitleJump.audioIndex,
+          timeMs: pendingSubtitleJump.timeMs,
+        });
+        return;
+      }
     }
 
     if (currentInteractionElement) {
@@ -1421,6 +1447,16 @@ const Slide: React.FC<SlideProps> = ({
     });
   }, []);
 
+  const canJumpToSubtitleTarget = useCallback(
+    (target: SlidePlayerSubtitleJumpTarget) =>
+      canReachSubtitleJumpTarget({
+        currentIndex,
+        slideElementList,
+        targetSlideIndex: audioSlideIndexes[target.audioIndex],
+      }),
+    [audioSlideIndexes, currentIndex, slideElementList]
+  );
+
   const handleSubtitleJump = useCallback(
     (
       target: SlidePlayerSubtitleJumpTarget,
@@ -1431,6 +1467,10 @@ const Slide: React.FC<SlideProps> = ({
       const targetSlideIndex = audioSlideIndexes[target.audioIndex];
 
       if (!targetAudioKey || targetSlideIndex == null) {
+        return false;
+      }
+
+      if (!canJumpToSubtitleTarget(target)) {
         return false;
       }
 
@@ -1468,6 +1508,7 @@ const Slide: React.FC<SlideProps> = ({
     [
       audioList,
       audioSlideIndexes,
+      canJumpToSubtitleTarget,
       currentIndex,
       goTo,
       requestSubtitleCueSeek,
@@ -1918,6 +1959,7 @@ const Slide: React.FC<SlideProps> = ({
               onNext={handleNext}
               onPrev={handlePrev}
               onSubtitleJump={handleSubtitleJump}
+              canJumpToSubtitleTarget={canJumpToSubtitleTarget}
               prevDisabled={!canGoPrev}
               showControls={playerVisible}
               subtitleSeekRequest={subtitleSeekRequest}

--- a/src/components/Slide/useSlide.ts
+++ b/src/components/Slide/useSlide.ts
@@ -19,6 +19,7 @@ export interface UseSlideResult {
   slideElementList: Element[];
   currentIndex: number;
   audioList: SlideAudioItem[];
+  audioSlideIndexes: number[];
   currentAudioSequenceIndexes: number[];
   currentStepHasSpeakableElement: boolean;
   currentInteractionElement?: Element;
@@ -26,6 +27,7 @@ export interface UseSlideResult {
   canGoNext: boolean;
   handlePrev: () => void;
   handleNext: () => void;
+  handleGoTo: (index: number) => void;
 }
 
 const getMarkerElementList = (elementList: Element[]) =>
@@ -141,6 +143,18 @@ const getSlideAudioSequenceMap = (
     },
     new Map<number, number[]>()
   );
+
+const getAudioSlideIndexes = (slideAudioSequenceMap: Map<number, number[]>) => {
+  const audioSlideIndexes: number[] = [];
+
+  slideAudioSequenceMap.forEach((audioIndexes, slideIndex) => {
+    audioIndexes.forEach((audioIndex) => {
+      audioSlideIndexes[audioIndex] = slideIndex;
+    });
+  });
+
+  return audioSlideIndexes;
+};
 
 const getInitialSlideIndex = (slideElementList: Element[]) => {
   const visibleIndex = slideElementList.findIndex(
@@ -277,6 +291,10 @@ const useSlide = (elementList: Element[] = []): UseSlideResult => {
       ),
     [audioIndexMap, markerElementIndexes, stableElementList]
   );
+  const audioSlideIndexes = useMemo(
+    () => getAudioSlideIndexes(slideAudioSequenceMap),
+    [slideAudioSequenceMap]
+  );
   const [currentIndex, setCurrentIndex] = useState(() =>
     getInitialSlideIndex(slideElementList)
   );
@@ -320,6 +338,19 @@ const useSlide = (elementList: Element[] = []): UseSlideResult => {
       return Math.min(prevIndex + 1, slideElementList.length - 1);
     });
   }, [slideElementList.length]);
+
+  const handleGoTo = useCallback(
+    (index: number) => {
+      if (!Number.isFinite(index) || slideElementList.length === 0) {
+        return;
+      }
+
+      setCurrentIndex(
+        Math.min(Math.max(Math.trunc(index), 0), slideElementList.length - 1)
+      );
+    },
+    [slideElementList.length]
+  );
 
   const canGoPrev = currentIndex > 0;
   const canGoNext =
@@ -385,6 +416,7 @@ const useSlide = (elementList: Element[] = []): UseSlideResult => {
     slideElementList,
     currentIndex,
     audioList,
+    audioSlideIndexes,
     currentAudioSequenceIndexes,
     currentStepHasSpeakableElement,
     currentInteractionElement,
@@ -392,6 +424,7 @@ const useSlide = (elementList: Element[] = []): UseSlideResult => {
     canGoNext,
     handlePrev,
     handleNext,
+    handleGoTo,
   };
 };
 

--- a/src/components/Slide/utils/audioSegments.test.ts
+++ b/src/components/Slide/utils/audioSegments.test.ts
@@ -89,4 +89,28 @@ describe("getSortedAudioSegments", () => {
       )
     ).toEqual(["first", "second"]);
   });
+
+  it("refreshes the cached sort when a streaming segment object is replaced", () => {
+    const originalSegment = {
+      segment_index: 0,
+      audio_data: "original",
+      duration_ms: 100,
+      is_final: false,
+    };
+    const replacementSegment = {
+      segment_index: 0,
+      audio_data: "updated",
+      duration_ms: 100,
+      is_final: false,
+    };
+    const audioSegments = [originalSegment];
+
+    expect(getSortedAudioSegments({ audioSegments })[0]).toBe(originalSegment);
+
+    audioSegments[0] = replacementSegment;
+
+    expect(getSortedAudioSegments({ audioSegments })[0]).toBe(
+      replacementSegment
+    );
+  });
 });

--- a/src/components/Slide/utils/audioSegments.test.ts
+++ b/src/components/Slide/utils/audioSegments.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import type { SlideAudioItem } from "../useSlide";
+import { getSortedAudioSegments } from "./audioSegments";
+
+type SlideAudioSegments = NonNullable<SlideAudioItem["audioSegments"]>;
+
+describe("getSortedAudioSegments", () => {
+  it("sorts segments by segment index", () => {
+    expect(
+      getSortedAudioSegments({
+        audioSegments: [
+          {
+            segment_index: 2,
+            audio_data: "third",
+            duration_ms: 300,
+            is_final: true,
+          },
+          {
+            segment_index: 0,
+            audio_data: "first",
+            duration_ms: 100,
+            is_final: false,
+          },
+          {
+            segment_index: 1,
+            audio_data: "second",
+            duration_ms: 200,
+            is_final: false,
+          },
+        ],
+      }).map((segment) => segment.audio_data)
+    ).toEqual(["first", "second", "third"]);
+  });
+
+  it("filters nullish segments and handles missing segment indexes defensively", () => {
+    const audioSegments = [
+      {
+        segment_index: 2,
+        audio_data: "third",
+        duration_ms: 300,
+        is_final: true,
+      },
+      null,
+      {
+        audio_data: "missing-index",
+        duration_ms: 100,
+        is_final: false,
+      },
+      undefined,
+      {
+        segment_index: 1,
+        audio_data: "second",
+        duration_ms: 200,
+        is_final: false,
+      },
+    ] as unknown as SlideAudioSegments;
+
+    expect(() => getSortedAudioSegments({ audioSegments })).not.toThrow();
+    expect(
+      getSortedAudioSegments({ audioSegments }).map(
+        (segment) => segment.audio_data
+      )
+    ).toEqual(["missing-index", "second", "third"]);
+  });
+
+  it("refreshes the cached sort when a streaming segment array mutates", () => {
+    const audioSegments = [
+      {
+        segment_index: 1,
+        audio_data: "second",
+        duration_ms: 200,
+        is_final: false,
+      },
+    ];
+
+    expect(getSortedAudioSegments({ audioSegments })).toHaveLength(1);
+
+    audioSegments.push({
+      segment_index: 0,
+      audio_data: "first",
+      duration_ms: 100,
+      is_final: false,
+    });
+
+    expect(
+      getSortedAudioSegments({ audioSegments }).map(
+        (segment) => segment.audio_data
+      )
+    ).toEqual(["first", "second"]);
+  });
+});

--- a/src/components/Slide/utils/audioSegments.ts
+++ b/src/components/Slide/utils/audioSegments.ts
@@ -6,38 +6,23 @@ type SlideAudioSegment = SlideAudioSegments[number];
 const sortedAudioSegmentsCache = new WeakMap<
   SlideAudioSegments,
   {
-    signature: string;
+    lastSegments: Array<SlideAudioSegment | null | undefined>;
     sortedSegments: SlideAudioSegments;
   }
 >();
-const audioSegmentIdentityCache = new WeakMap<object, number>();
-let nextAudioSegmentIdentity = 0;
 
 const isPresentAudioSegment = (
   segment: SlideAudioSegment | null | undefined
 ): segment is SlideAudioSegment => Boolean(segment);
 
-const getAudioSegmentIdentity = (segment: SlideAudioSegment) => {
-  const cachedIdentity = audioSegmentIdentityCache.get(segment);
-
-  if (cachedIdentity != null) {
-    return cachedIdentity;
-  }
-
-  nextAudioSegmentIdentity += 1;
-  audioSegmentIdentityCache.set(segment, nextAudioSegmentIdentity);
-
-  return nextAudioSegmentIdentity;
-};
-
-const getAudioSegmentsSignature = (audioSegments: SlideAudioSegments) =>
-  audioSegments
-    .map((segment) =>
-      segment
-        ? `${getAudioSegmentIdentity(segment)}:${segment.segment_index ?? 0}:${Number(segment.duration_ms ?? 0)}:${segment.is_final ? "1" : "0"}`
-        : ""
-    )
-    .join("|");
+const hasSameSegmentReferences = (
+  previousSegments: Array<SlideAudioSegment | null | undefined>,
+  nextSegments: SlideAudioSegments
+) =>
+  previousSegments.length === nextSegments.length &&
+  previousSegments.every(
+    (previousSegment, index) => previousSegment === nextSegments[index]
+  );
 
 export const getSortedAudioSegments = (audioItem?: SlideAudioItem) => {
   const audioSegments = audioItem?.audioSegments;
@@ -46,10 +31,12 @@ export const getSortedAudioSegments = (audioItem?: SlideAudioItem) => {
     return [];
   }
 
-  const signature = getAudioSegmentsSignature(audioSegments);
   const cachedSegments = sortedAudioSegmentsCache.get(audioSegments);
 
-  if (cachedSegments?.signature === signature) {
+  if (
+    cachedSegments &&
+    hasSameSegmentReferences(cachedSegments.lastSegments, audioSegments)
+  ) {
     return cachedSegments.sortedSegments;
   }
 
@@ -61,7 +48,7 @@ export const getSortedAudioSegments = (audioItem?: SlideAudioItem) => {
     );
 
   sortedAudioSegmentsCache.set(audioSegments, {
-    signature,
+    lastSegments: [...audioSegments],
     sortedSegments,
   });
 

--- a/src/components/Slide/utils/audioSegments.ts
+++ b/src/components/Slide/utils/audioSegments.ts
@@ -1,0 +1,54 @@
+import type { SlideAudioItem } from "../useSlide";
+
+type SlideAudioSegments = NonNullable<SlideAudioItem["audioSegments"]>;
+type SlideAudioSegment = SlideAudioSegments[number];
+
+const sortedAudioSegmentsCache = new WeakMap<
+  SlideAudioSegments,
+  {
+    signature: string;
+    sortedSegments: SlideAudioSegments;
+  }
+>();
+
+const isPresentAudioSegment = (
+  segment: SlideAudioSegment | null | undefined
+): segment is SlideAudioSegment => Boolean(segment);
+
+const getAudioSegmentsSignature = (audioSegments: SlideAudioSegments) =>
+  audioSegments
+    .map((segment) =>
+      segment
+        ? `${segment.segment_index ?? 0}:${Number(segment.duration_ms ?? 0)}:${segment.is_final ? "1" : "0"}`
+        : ""
+    )
+    .join("|");
+
+export const getSortedAudioSegments = (audioItem?: SlideAudioItem) => {
+  const audioSegments = audioItem?.audioSegments;
+
+  if (!audioSegments) {
+    return [];
+  }
+
+  const signature = getAudioSegmentsSignature(audioSegments);
+  const cachedSegments = sortedAudioSegmentsCache.get(audioSegments);
+
+  if (cachedSegments?.signature === signature) {
+    return cachedSegments.sortedSegments;
+  }
+
+  const sortedSegments = audioSegments
+    .filter(isPresentAudioSegment)
+    .sort(
+      (prevSegment, nextSegment) =>
+        (prevSegment?.segment_index ?? 0) - (nextSegment?.segment_index ?? 0)
+    );
+
+  sortedAudioSegmentsCache.set(audioSegments, {
+    signature,
+    sortedSegments,
+  });
+
+  return sortedSegments;
+};

--- a/src/components/Slide/utils/audioSegments.ts
+++ b/src/components/Slide/utils/audioSegments.ts
@@ -10,16 +10,31 @@ const sortedAudioSegmentsCache = new WeakMap<
     sortedSegments: SlideAudioSegments;
   }
 >();
+const audioSegmentIdentityCache = new WeakMap<object, number>();
+let nextAudioSegmentIdentity = 0;
 
 const isPresentAudioSegment = (
   segment: SlideAudioSegment | null | undefined
 ): segment is SlideAudioSegment => Boolean(segment);
 
+const getAudioSegmentIdentity = (segment: SlideAudioSegment) => {
+  const cachedIdentity = audioSegmentIdentityCache.get(segment);
+
+  if (cachedIdentity != null) {
+    return cachedIdentity;
+  }
+
+  nextAudioSegmentIdentity += 1;
+  audioSegmentIdentityCache.set(segment, nextAudioSegmentIdentity);
+
+  return nextAudioSegmentIdentity;
+};
+
 const getAudioSegmentsSignature = (audioSegments: SlideAudioSegments) =>
   audioSegments
     .map((segment) =>
       segment
-        ? `${segment.segment_index ?? 0}:${Number(segment.duration_ms ?? 0)}:${segment.is_final ? "1" : "0"}`
+        ? `${getAudioSegmentIdentity(segment)}:${segment.segment_index ?? 0}:${Number(segment.duration_ms ?? 0)}:${segment.is_final ? "1" : "0"}`
         : ""
     )
     .join("|");

--- a/src/components/Slide/utils/subtitleCue.test.ts
+++ b/src/components/Slide/utils/subtitleCue.test.ts
@@ -46,6 +46,22 @@ describe("getVisibleSubtitleText", () => {
       )
     ).toBe("");
   });
+
+  it("defaults non-finite playback time to zero", () => {
+    expect(
+      getVisibleSubtitleText(
+        [
+          {
+            text: "Opening",
+            start_ms: 0,
+            end_ms: 1_000,
+            segment_index: 0,
+          },
+        ],
+        Number.NaN
+      )
+    ).toBe("Opening");
+  });
 });
 
 describe("getSubtitleCueJumpTime", () => {
@@ -132,6 +148,16 @@ describe("getSubtitleCueJumpTime", () => {
         direction: "next",
       })
     ).toBeNull();
+  });
+
+  it("defaults non-finite playback time to zero", () => {
+    expect(
+      getSubtitleCueJumpTime({
+        subtitleCues,
+        currentTimeMs: Number.NaN,
+        direction: "next",
+      })
+    ).toBe(1_500);
   });
 
   it("treats duplicate cue start times as one jump target", () => {
@@ -310,5 +336,19 @@ describe("getSubtitleCueJumpTarget", () => {
         direction: "next",
       })
     ).toBeNull();
+  });
+
+  it("defaults non-finite current time to zero for cross-track targets", () => {
+    expect(
+      getSubtitleCueJumpTarget({
+        tracks,
+        currentAudioIndex: 1,
+        currentTimeMs: Number.NaN,
+        direction: "next",
+      })
+    ).toEqual({
+      audioIndex: 1,
+      timeMs: 4_000,
+    });
   });
 });

--- a/src/components/Slide/utils/subtitleCue.test.ts
+++ b/src/components/Slide/utils/subtitleCue.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { getSubtitleCueJumpTime, getVisibleSubtitleText } from "./subtitleCue";
+import {
+  getSubtitleCueJumpTarget,
+  getSubtitleCueJumpTime,
+  getVisibleSubtitleText,
+} from "./subtitleCue";
 
 describe("getVisibleSubtitleText", () => {
   it("joins currently visible cues by visual order", () => {
@@ -157,6 +161,153 @@ describe("getSubtitleCueJumpTime", () => {
         ],
         currentTimeMs: 300,
         direction: "previous",
+      })
+    ).toBeNull();
+  });
+});
+
+describe("getSubtitleCueJumpTarget", () => {
+  const tracks = [
+    {
+      subtitleCues: [
+        {
+          text: "First track opening",
+          start_ms: 0,
+          end_ms: 1_000,
+          segment_index: 0,
+        },
+        {
+          text: "First track closing",
+          start_ms: 2_000,
+          end_ms: 3_000,
+          segment_index: 1,
+        },
+      ],
+    },
+    {
+      subtitleCues: [
+        {
+          text: "Second track opening",
+          start_ms: 0,
+          end_ms: 1_000,
+          segment_index: 0,
+        },
+        {
+          text: "Second track closing",
+          start_ms: 4_000,
+          end_ms: 5_000,
+          segment_index: 1,
+        },
+      ],
+    },
+    {
+      subtitleCues: [],
+    },
+    {
+      subtitleCues: [
+        {
+          text: "Fourth track opening",
+          start_ms: 0,
+          end_ms: 1_000,
+          segment_index: 0,
+        },
+      ],
+    },
+  ];
+
+  it("returns a next target inside the current audio track", () => {
+    expect(
+      getSubtitleCueJumpTarget({
+        tracks,
+        currentAudioIndex: 0,
+        currentTimeMs: 500,
+        direction: "next",
+      })
+    ).toEqual({
+      audioIndex: 0,
+      timeMs: 2_000,
+    });
+  });
+
+  it("returns the first cue in the next audio track when current audio has no next target", () => {
+    expect(
+      getSubtitleCueJumpTarget({
+        tracks,
+        currentAudioIndex: 0,
+        currentTimeMs: 2_500,
+        direction: "next",
+      })
+    ).toEqual({
+      audioIndex: 1,
+      timeMs: 0,
+    });
+  });
+
+  it("skips audio tracks without subtitle cues when moving forward", () => {
+    expect(
+      getSubtitleCueJumpTarget({
+        tracks,
+        currentAudioIndex: 1,
+        currentTimeMs: 4_500,
+        direction: "next",
+      })
+    ).toEqual({
+      audioIndex: 3,
+      timeMs: 0,
+    });
+  });
+
+  it("returns a previous target inside the current audio track", () => {
+    expect(
+      getSubtitleCueJumpTarget({
+        tracks,
+        currentAudioIndex: 1,
+        currentTimeMs: 4_500,
+        direction: "previous",
+      })
+    ).toEqual({
+      audioIndex: 1,
+      timeMs: 0,
+    });
+  });
+
+  it("returns the last cue in the previous audio track when current audio has no previous target", () => {
+    expect(
+      getSubtitleCueJumpTarget({
+        tracks,
+        currentAudioIndex: 1,
+        currentTimeMs: 0,
+        direction: "previous",
+      })
+    ).toEqual({
+      audioIndex: 0,
+      timeMs: 2_000,
+    });
+  });
+
+  it("returns null when no subtitle target exists across tracks", () => {
+    expect(
+      getSubtitleCueJumpTarget({
+        tracks,
+        currentAudioIndex: 0,
+        currentTimeMs: 0,
+        direction: "previous",
+      })
+    ).toBeNull();
+    expect(
+      getSubtitleCueJumpTarget({
+        tracks,
+        currentAudioIndex: 3,
+        currentTimeMs: 100,
+        direction: "next",
+      })
+    ).toBeNull();
+    expect(
+      getSubtitleCueJumpTarget({
+        tracks,
+        currentAudioIndex: -1,
+        currentTimeMs: 100,
+        direction: "next",
       })
     ).toBeNull();
   });

--- a/src/components/Slide/utils/subtitleCue.ts
+++ b/src/components/Slide/utils/subtitleCue.ts
@@ -136,7 +136,7 @@ const getFirstSubtitleCueStartTimeMs = (subtitleCues: ElementSubtitleCue[]) => {
 };
 
 const getLastSubtitleCueStartTimeMs = (subtitleCues: ElementSubtitleCue[]) => {
-  const lastSubtitleCue = subtitleCues[subtitleCues.length - 1];
+  const lastSubtitleCue = subtitleCues.at(-1);
 
   return lastSubtitleCue ? getSubtitleCueStartTimeMs(lastSubtitleCue) : null;
 };

--- a/src/components/Slide/utils/subtitleCue.ts
+++ b/src/components/Slide/utils/subtitleCue.ts
@@ -136,7 +136,7 @@ const getFirstSubtitleCueStartTimeMs = (subtitleCues: ElementSubtitleCue[]) => {
 };
 
 const getLastSubtitleCueStartTimeMs = (subtitleCues: ElementSubtitleCue[]) => {
-  const lastSubtitleCue = subtitleCues.at(-1);
+  const lastSubtitleCue = subtitleCues[subtitleCues.length - 1];
 
   return lastSubtitleCue ? getSubtitleCueStartTimeMs(lastSubtitleCue) : null;
 };

--- a/src/components/Slide/utils/subtitleCue.ts
+++ b/src/components/Slide/utils/subtitleCue.ts
@@ -3,6 +3,15 @@ import type { ElementSubtitleCue } from "../types";
 /** Direction for subtitle cue jump navigation. */
 export type SubtitleCueJumpDirection = "previous" | "next";
 
+export interface SubtitleCueJumpTrack {
+  subtitleCues?: ElementSubtitleCue[];
+}
+
+export interface SubtitleCueJumpTarget {
+  audioIndex: number;
+  timeMs: number;
+}
+
 export const getVisibleSubtitleText = (
   subtitleCues: ElementSubtitleCue[] = [],
   currentTimeMs: number
@@ -111,6 +120,18 @@ const getNextSubtitleCueStartTimeMs = (
   return nextSubtitleCue ? getSubtitleCueStartTimeMs(nextSubtitleCue) : null;
 };
 
+const getFirstSubtitleCueStartTimeMs = (subtitleCues: ElementSubtitleCue[]) => {
+  const firstSubtitleCue = subtitleCues[0];
+
+  return firstSubtitleCue ? getSubtitleCueStartTimeMs(firstSubtitleCue) : null;
+};
+
+const getLastSubtitleCueStartTimeMs = (subtitleCues: ElementSubtitleCue[]) => {
+  const lastSubtitleCue = subtitleCues[subtitleCues.length - 1];
+
+  return lastSubtitleCue ? getSubtitleCueStartTimeMs(lastSubtitleCue) : null;
+};
+
 /** Options used to resolve a subtitle cue jump target. */
 export interface GetSubtitleCueJumpTimeOptions {
   currentTimeMs: number;
@@ -147,4 +168,79 @@ export const getSubtitleCueJumpTime = ({
     sortedSubtitleCues,
     activeStartTimeMs ?? normalizedCurrentTimeMs
   );
+};
+
+export interface GetSubtitleCueJumpTargetOptions {
+  currentAudioIndex: number;
+  currentTimeMs: number;
+  direction: SubtitleCueJumpDirection;
+  tracks?: SubtitleCueJumpTrack[];
+}
+
+export const getSubtitleCueJumpTarget = ({
+  currentAudioIndex,
+  currentTimeMs,
+  direction,
+  tracks = [],
+}: GetSubtitleCueJumpTargetOptions): SubtitleCueJumpTarget | null => {
+  if (
+    tracks.length === 0 ||
+    currentAudioIndex < 0 ||
+    currentAudioIndex >= tracks.length
+  ) {
+    return null;
+  }
+
+  const normalizedCurrentTimeMs = Math.max(Number(currentTimeMs), 0);
+
+  if (direction === "next") {
+    for (
+      let audioIndex = currentAudioIndex;
+      audioIndex < tracks.length;
+      audioIndex += 1
+    ) {
+      const sortedSubtitleCues = sortSubtitleCuesByPlaybackTime(
+        tracks[audioIndex]?.subtitleCues ?? []
+      );
+      const timeMs =
+        audioIndex === currentAudioIndex
+          ? getNextSubtitleCueStartTimeMs(
+              sortedSubtitleCues,
+              normalizedCurrentTimeMs
+            )
+          : getFirstSubtitleCueStartTimeMs(sortedSubtitleCues);
+
+      if (timeMs !== null) {
+        return {
+          audioIndex,
+          timeMs,
+        };
+      }
+    }
+
+    return null;
+  }
+
+  for (let audioIndex = currentAudioIndex; audioIndex >= 0; audioIndex -= 1) {
+    const sortedSubtitleCues = sortSubtitleCuesByPlaybackTime(
+      tracks[audioIndex]?.subtitleCues ?? []
+    );
+    const timeMs =
+      audioIndex === currentAudioIndex
+        ? getSubtitleCueJumpTime({
+            currentTimeMs: normalizedCurrentTimeMs,
+            direction,
+            subtitleCues: sortedSubtitleCues,
+          })
+        : getLastSubtitleCueStartTimeMs(sortedSubtitleCues);
+
+    if (timeMs !== null) {
+      return {
+        audioIndex,
+        timeMs,
+      };
+    }
+  }
+
+  return null;
 };

--- a/src/components/Slide/utils/subtitleCue.ts
+++ b/src/components/Slide/utils/subtitleCue.ts
@@ -12,15 +12,23 @@ export interface SubtitleCueJumpTarget {
   timeMs: number;
 }
 
+const normalizePlaybackTimeMs = (timeMs: number) => {
+  const parsedTimeMs = Number(timeMs);
+
+  return Number.isFinite(parsedTimeMs) ? Math.max(parsedTimeMs, 0) : 0;
+};
+
 export const getVisibleSubtitleText = (
   subtitleCues: ElementSubtitleCue[] = [],
   currentTimeMs: number
-) =>
-  subtitleCues
+): string => {
+  const normalizedCurrentTimeMs = normalizePlaybackTimeMs(currentTimeMs);
+
+  return subtitleCues
     .filter(
       (subtitleCue) =>
-        currentTimeMs >= subtitleCue.start_ms &&
-        currentTimeMs < subtitleCue.end_ms
+        normalizedCurrentTimeMs >= subtitleCue.start_ms &&
+        normalizedCurrentTimeMs < subtitleCue.end_ms
     )
     .sort(
       (prevCue, nextCue) =>
@@ -32,6 +40,7 @@ export const getVisibleSubtitleText = (
     .map((subtitleCue) => subtitleCue.text.trim())
     .filter(Boolean)
     .join("\n");
+};
 
 const getSubtitleCueStartTimeMs = (subtitleCue: ElementSubtitleCue) =>
   Math.max(Number(subtitleCue.start_ms ?? 0), 0);
@@ -150,7 +159,7 @@ export const getSubtitleCueJumpTime = ({
   }
 
   const sortedSubtitleCues = sortSubtitleCuesByPlaybackTime(subtitleCues);
-  const normalizedCurrentTimeMs = Math.max(Number(currentTimeMs), 0);
+  const normalizedCurrentTimeMs = normalizePlaybackTimeMs(currentTimeMs);
 
   if (direction === "next") {
     return getNextSubtitleCueStartTimeMs(
@@ -191,7 +200,7 @@ export const getSubtitleCueJumpTarget = ({
     return null;
   }
 
-  const normalizedCurrentTimeMs = Math.max(Number(currentTimeMs), 0);
+  const normalizedCurrentTimeMs = normalizePlaybackTimeMs(currentTimeMs);
 
   if (direction === "next") {
     for (

--- a/src/components/Slide/utils/subtitleJumpNavigation.test.ts
+++ b/src/components/Slide/utils/subtitleJumpNavigation.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import type { Element } from "../types";
+import { canReachSubtitleJumpTarget } from "./subtitleJumpNavigation";
+
+const marker = (overrides: Partial<Element> = {}): Element => ({
+  type: "html",
+  content: "",
+  is_marker: true,
+  ...overrides,
+});
+
+const unresolvedInteraction = marker({
+  type: "interaction",
+  user_input: "",
+});
+
+const resolvedInteraction = marker({
+  type: "interaction",
+  user_input: "Done",
+});
+
+describe("canReachSubtitleJumpTarget", () => {
+  it("blocks subtitle jumps that cross an unresolved interaction", () => {
+    expect(
+      canReachSubtitleJumpTarget({
+        currentIndex: 0,
+        targetSlideIndex: 2,
+        slideElementList: [marker(), unresolvedInteraction, marker()],
+      })
+    ).toBe(false);
+  });
+
+  it("blocks subtitle jumps from an unresolved interaction slide", () => {
+    expect(
+      canReachSubtitleJumpTarget({
+        currentIndex: 1,
+        targetSlideIndex: 1,
+        slideElementList: [marker(), unresolvedInteraction],
+      })
+    ).toBe(false);
+  });
+
+  it("allows subtitle jumps across resolved interactions", () => {
+    expect(
+      canReachSubtitleJumpTarget({
+        currentIndex: 0,
+        targetSlideIndex: 2,
+        slideElementList: [marker(), resolvedInteraction, marker()],
+      })
+    ).toBe(true);
+  });
+
+  it("allows backward subtitle jumps without applying forward interaction gates", () => {
+    expect(
+      canReachSubtitleJumpTarget({
+        currentIndex: 2,
+        targetSlideIndex: 0,
+        slideElementList: [marker(), unresolvedInteraction, marker()],
+      })
+    ).toBe(true);
+  });
+
+  it("rejects missing target slide indexes", () => {
+    expect(
+      canReachSubtitleJumpTarget({
+        currentIndex: 0,
+        targetSlideIndex: undefined,
+        slideElementList: [marker()],
+      })
+    ).toBe(false);
+  });
+});

--- a/src/components/Slide/utils/subtitleJumpNavigation.test.ts
+++ b/src/components/Slide/utils/subtitleJumpNavigation.test.ts
@@ -51,6 +51,17 @@ describe("canReachSubtitleJumpTarget", () => {
     ).toBe(true);
   });
 
+  it("allows subtitle jumps after the current interaction is resolved locally", () => {
+    expect(
+      canReachSubtitleJumpTarget({
+        currentIndex: 1,
+        targetSlideIndex: 2,
+        resolvedCurrentInteractionElement: resolvedInteraction,
+        slideElementList: [marker(), unresolvedInteraction, marker()],
+      })
+    ).toBe(true);
+  });
+
   it("allows backward subtitle jumps without applying forward interaction gates", () => {
     expect(
       canReachSubtitleJumpTarget({

--- a/src/components/Slide/utils/subtitleJumpNavigation.ts
+++ b/src/components/Slide/utils/subtitleJumpNavigation.ts
@@ -1,0 +1,41 @@
+import type { Element } from "../types";
+
+export const hasResolvedInteractionElement = (element?: Element) =>
+  Boolean(element?.readonly || element?.user_input?.trim());
+
+export const isUnresolvedInteractionElement = (element?: Element) =>
+  element?.type === "interaction" && !hasResolvedInteractionElement(element);
+
+export interface CanReachSubtitleJumpTargetOptions {
+  currentIndex: number;
+  slideElementList: Element[];
+  targetSlideIndex: number | undefined;
+}
+
+export const canReachSubtitleJumpTarget = ({
+  currentIndex,
+  slideElementList,
+  targetSlideIndex,
+}: CanReachSubtitleJumpTargetOptions) => {
+  if (targetSlideIndex == null || targetSlideIndex < 0) {
+    return false;
+  }
+
+  if (targetSlideIndex < currentIndex) {
+    return true;
+  }
+
+  const firstCheckedIndex = Math.max(currentIndex, 0);
+
+  for (
+    let slideIndex = firstCheckedIndex;
+    slideIndex <= targetSlideIndex;
+    slideIndex += 1
+  ) {
+    if (isUnresolvedInteractionElement(slideElementList[slideIndex])) {
+      return false;
+    }
+  }
+
+  return true;
+};

--- a/src/components/Slide/utils/subtitleJumpNavigation.ts
+++ b/src/components/Slide/utils/subtitleJumpNavigation.ts
@@ -8,12 +8,14 @@ export const isUnresolvedInteractionElement = (element?: Element) =>
 
 export interface CanReachSubtitleJumpTargetOptions {
   currentIndex: number;
+  resolvedCurrentInteractionElement?: Element;
   slideElementList: Element[];
   targetSlideIndex: number | undefined;
 }
 
 export const canReachSubtitleJumpTarget = ({
   currentIndex,
+  resolvedCurrentInteractionElement,
   slideElementList,
   targetSlideIndex,
 }: CanReachSubtitleJumpTargetOptions) => {
@@ -32,7 +34,15 @@ export const canReachSubtitleJumpTarget = ({
     slideIndex <= targetSlideIndex;
     slideIndex += 1
   ) {
-    if (isUnresolvedInteractionElement(slideElementList[slideIndex])) {
+    const isLocallyResolvedCurrentInteraction =
+      slideIndex === currentIndex &&
+      slideElementList[slideIndex]?.type === "interaction" &&
+      hasResolvedInteractionElement(resolvedCurrentInteractionElement);
+
+    if (
+      !isLocallyResolvedCurrentInteraction &&
+      isUnresolvedInteractionElement(slideElementList[slideIndex])
+    ) {
       return false;
     }
   }


### PR DESCRIPTION
## Summary
- allow subtitle cue jumps to resolve targets across audio items and slide pages
- navigate to the target slide/audio before seeking, preserving the current playback preference
- add cross-track subtitle target tests and keep local cache/tooling noise out of lint/format checks

## Verification
- npm test
- pnpm exec vitest run --config /private/tmp/markdown-flow-ui-vitest-unit.config.ts src/components/Slide/utils/subtitleCue.test.ts src/components/Slide/utils/segmentSeek.test.ts src/components/Slide/utils/playerKeyboardShortcuts.test.ts
- npm run typecheck:exports
- npm run build
- npm run lint
- npm run format:check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subtitle navigation now works across multiple audio tracks, making next/previous subtitle jumps more reliable.
  * Added smoother slide-to-slide jumping when navigating from subtitles.

* **Bug Fixes**
  * Improved handling of invalid or missing playback times so subtitle display and seeking stay stable.
  * Fixed subtitle jump behavior around unresolved interactions and restricted playback states.

* **Chores**
  * Updated ignore rules to exclude local package store files from repository tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->