### PR TITLE
fix: suppress image lint false positives

### DIFF
--- a/src/components/MarkdownFlowEditor/components/EditorToolbar.tsx
+++ b/src/components/MarkdownFlowEditor/components/EditorToolbar.tsx
@@ -2,7 +2,7 @@ import { memo, useCallback } from "react";
 import {
   Braces,
   FileType,
-  Image,
+  Image as ImageIcon,
   TextCursorInput,
   // Link,
   SquareCheck,
@@ -255,7 +255,7 @@ const EditorToolbar: React.FC<EditorToolbarProps> = ({
                 aria-label={labels.image}
                 title={labels.image}
               >
-                <Image strokeWidth={1.75} size={ICON_SIZE} />
+                <ImageIcon strokeWidth={1.75} size={ICON_SIZE} />
               </button>
             </TooltipTrigger>
             <TooltipContent side="top">{labels.image ?? ""}</TooltipContent>

--- a/src/components/Slide/Slide.stories.tsx
+++ b/src/components/Slide/Slide.stories.tsx
@@ -3240,6 +3240,7 @@ export const HistorySlides: Story = {
     fullscreenHeader: {
       content: (
         <div className="flex min-w-0 items-center gap-2 overflow-hidden text-[16px] font-bold leading-6 text-black">
+          {/* eslint-disable-next-line @next/next/no-img-element -- Storybook uses a static avatar fixture outside Next image optimization. */}
           <img
             alt="Nike老师"
             className="h-8 w-8 shrink-0 rounded-full object-cover"


### PR DESCRIPTION
## Summary
- Alias the lucide image icon as ImageIcon so JSX a11y lint does not treat it as an HTML image element.
- Add a scoped Storybook no-img-element disable for a static avatar fixture.

## Why
- This separates the lint-only image cleanup from the cross-page subtitle jump PR.
- Without both image lint cleanups, the repository exceeds the current lint warning threshold.

## Validation
- pnpm exec next lint --file src/components/MarkdownFlowEditor/components/EditorToolbar.tsx --max-warnings 0
- npm test
- npm run lint
- pnpm exec prettier --check src/components/MarkdownFlowEditor/components/EditorToolbar.tsx src/components/Slide/Slide.stories.tsx
- npm run typecheck:exports
- npm run build