### PR TITLE
fix: preserve subtitle jump audio target

### DIFF
--- a/src/components/Slide/Player.tsx
+++ b/src/components/Slide/Player.tsx
@@ -59,6 +59,7 @@ import {
 import { getSortedAudioSegments } from "./utils/audioSegments";
 import {
   getSubtitleCueJumpTarget,
+  shouldClearSubtitleCueJumpTarget,
   type SubtitleCueJumpDirection,
   type SubtitleCueJumpTarget,
   type SubtitleCueJumpTrack,
@@ -793,10 +794,20 @@ const Player = ({
       }
 
       playbackTimeMsRef.current = nextPlaybackTimeMs;
+      if (
+        shouldClearSubtitleCueJumpTarget({
+          currentAudioIndex,
+          currentTimeMs: nextPlaybackTimeMs,
+          target: lastSubtitleJumpTargetRef.current,
+        })
+      ) {
+        lastSubtitleJumpTargetRef.current = null;
+      }
+
       onPlaybackTimeChange?.(nextPlaybackTimeMs);
       updateSubtitleJumpAvailabilityRef.current(nextPlaybackTimeMs);
     },
-    [onPlaybackTimeChange]
+    [currentAudioIndex, onPlaybackTimeChange]
   );
 
   const syncPlaybackTime = useCallback(() => {

--- a/src/components/Slide/Player.tsx
+++ b/src/components/Slide/Player.tsx
@@ -364,6 +364,8 @@ const Player = ({
     (currentTimeMs: number) => void
   >(() => {});
   const lastSubtitleJumpAvailabilityTimeMsRef = useRef<number | null>(null);
+  const lastSubtitleJumpTargetRef =
+    useRef<SlidePlayerSubtitleJumpTarget | null>(null);
   const lastSubtitleSeekRequestIdRef = useRef<number | string | null>(null);
   const subtitleCueTracksCacheRef = useRef<SubtitleCueTracksCache | null>(null);
   const playbackAccessModeRef = useRef<
@@ -670,11 +672,18 @@ const Player = ({
   );
 
   const getSubtitleJumpTarget = useCallback(
-    (direction: SubtitleCueJumpDirection, currentTimeMs: number) => {
+    (
+      direction: SubtitleCueJumpDirection,
+      currentTimeMs: number,
+      options: {
+        excludeTarget?: SlidePlayerSubtitleJumpTarget | null;
+      } = {}
+    ) => {
       const target = getSubtitleCueJumpTarget({
         currentAudioIndex,
         currentTimeMs,
         direction,
+        excludeTarget: options.excludeTarget,
         tracks: subtitleCueTracks,
       });
 
@@ -1079,7 +1088,11 @@ const Player = ({
     (direction: SubtitleCueJumpDirection) => {
       const target = getSubtitleJumpTarget(
         direction,
-        getCurrentPlaybackTimeMs()
+        getCurrentPlaybackTimeMs(),
+        {
+          excludeTarget:
+            direction === "previous" ? lastSubtitleJumpTargetRef.current : null,
+        }
       );
 
       if (target === null) {
@@ -1087,15 +1100,27 @@ const Player = ({
       }
 
       if (target.audioIndex === currentAudioIndex) {
-        return seekToPlaybackTimeMs(target.timeMs);
+        const didSeek = seekToPlaybackTimeMs(target.timeMs);
+
+        if (didSeek) {
+          lastSubtitleJumpTargetRef.current = target;
+        }
+
+        return didSeek;
       }
 
-      return Boolean(
+      const didJump = Boolean(
         onSubtitleJump?.(
           target,
           suppressPlayerControlsWakeAfterNavigation(getNavigationContext())
         )
       );
+
+      if (didJump) {
+        lastSubtitleJumpTargetRef.current = target;
+      }
+
+      return didJump;
     },
     [
       currentAudioIndex,

--- a/src/components/Slide/Slide.tsx
+++ b/src/components/Slide/Slide.tsx
@@ -49,7 +49,10 @@ import {
 import { shouldPresentInteractionOverlay } from "./utils/interactionPlayback";
 import { shouldWakePlayerControlsAfterNavigation } from "./utils/playerNavigationContext";
 import { shouldAutoAdvanceIntoAppendedMarker } from "./utils/appendedMarkerAdvance";
-import { getPlaybackSequenceTransition } from "./utils/playbackSequence";
+import {
+  getPlaybackSequenceTransition,
+  shouldStartDefaultAudioSequence,
+} from "./utils/playbackSequence";
 import {
   canReachSubtitleJumpTarget,
   hasResolvedInteractionElement,
@@ -286,6 +289,7 @@ const Slide: React.FC<SlideProps> = ({
     currentIndex: -1,
     canGoNext: false,
   });
+  const shouldSkipDefaultAudioStartForSubtitleJumpRef = useRef(false);
   const {
     currentElementList,
     stepElementLists,
@@ -1009,6 +1013,9 @@ const Slide: React.FC<SlideProps> = ({
         // Keep the pending seek queued while the interaction overlay gates playback.
       } else {
         pendingSubtitleJumpRef.current = null;
+        // The default audio-start effect still sees the pre-seek render state.
+        // Skip it once so it does not replace the subtitle target audio.
+        shouldSkipDefaultAudioStartForSubtitleJumpRef.current = true;
         setCurrentAudioKey(pendingSubtitleJump.audioKey);
         requestSubtitleCueSeek({
           audioIndex: pendingSubtitleJump.audioIndex,
@@ -1126,19 +1133,21 @@ const Slide: React.FC<SlideProps> = ({
   ]);
 
   useEffect(() => {
-    if (currentAudioKey || currentAudioSequenceKeys.length === 0) {
-      return;
-    }
+    const shouldSkipDefaultAudioStart =
+      shouldSkipDefaultAudioStartForSubtitleJumpRef.current;
+    shouldSkipDefaultAudioStartForSubtitleJumpRef.current = false;
 
     if (
-      shouldPausePlaybackForCustomAction ||
-      !currentStepHasSpeakableElement ||
-      shouldBlockPlaybackForInteraction
+      !shouldStartDefaultAudioSequence({
+        currentAudioKey,
+        currentAudioSequenceLength: currentAudioSequenceKeys.length,
+        currentStepHasSpeakableElement,
+        hasCompletedCurrentStepAudio,
+        shouldBlockPlaybackForInteraction,
+        shouldPausePlaybackForCustomAction,
+        shouldSkipDefaultAudioStart,
+      })
     ) {
-      return;
-    }
-
-    if (hasCompletedCurrentStepAudio) {
       return;
     }
 

--- a/src/components/Slide/utils/playbackSequence.test.ts
+++ b/src/components/Slide/utils/playbackSequence.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { getPlaybackSequenceTransition } from "./playbackSequence";
+import {
+  getPlaybackSequenceTransition,
+  shouldStartDefaultAudioSequence,
+} from "./playbackSequence";
 
 describe("playbackSequence", () => {
   it("does not restart the current step after it already finished", () => {
@@ -43,5 +46,33 @@ describe("playbackSequence", () => {
       hasPlaybackContextChanged: true,
       shouldInitializeAudioSequence: true,
     });
+  });
+
+  it("starts the default audio sequence when the step has pending audio", () => {
+    expect(
+      shouldStartDefaultAudioSequence({
+        currentAudioKey: null,
+        currentAudioSequenceLength: 2,
+        currentStepHasSpeakableElement: true,
+        hasCompletedCurrentStepAudio: false,
+        shouldBlockPlaybackForInteraction: false,
+        shouldPausePlaybackForCustomAction: false,
+        shouldSkipDefaultAudioStart: false,
+      })
+    ).toBe(true);
+  });
+
+  it("does not start the default audio sequence after a subtitle jump selected a target audio", () => {
+    expect(
+      shouldStartDefaultAudioSequence({
+        currentAudioKey: null,
+        currentAudioSequenceLength: 2,
+        currentStepHasSpeakableElement: true,
+        hasCompletedCurrentStepAudio: false,
+        shouldBlockPlaybackForInteraction: false,
+        shouldPausePlaybackForCustomAction: false,
+        shouldSkipDefaultAudioStart: true,
+      })
+    ).toBe(false);
   });
 });

--- a/src/components/Slide/utils/playbackSequence.ts
+++ b/src/components/Slide/utils/playbackSequence.ts
@@ -10,6 +10,16 @@ export interface PlaybackSequenceTransitionResult {
   shouldInitializeAudioSequence: boolean;
 }
 
+export interface DefaultAudioSequenceStartOptions {
+  currentAudioKey: string | null;
+  currentAudioSequenceLength: number;
+  currentStepHasSpeakableElement: boolean;
+  hasCompletedCurrentStepAudio: boolean;
+  shouldBlockPlaybackForInteraction: boolean;
+  shouldPausePlaybackForCustomAction: boolean;
+  shouldSkipDefaultAudioStart: boolean;
+}
+
 export const getPlaybackSequenceTransition = ({
   previousResetKey,
   nextResetKey,
@@ -25,4 +35,32 @@ export const getPlaybackSequenceTransition = ({
     hasPlaybackContextChanged,
     shouldInitializeAudioSequence,
   };
+};
+
+export const shouldStartDefaultAudioSequence = ({
+  currentAudioKey,
+  currentAudioSequenceLength,
+  currentStepHasSpeakableElement,
+  hasCompletedCurrentStepAudio,
+  shouldBlockPlaybackForInteraction,
+  shouldPausePlaybackForCustomAction,
+  shouldSkipDefaultAudioStart,
+}: DefaultAudioSequenceStartOptions) => {
+  if (
+    currentAudioKey ||
+    currentAudioSequenceLength === 0 ||
+    shouldSkipDefaultAudioStart
+  ) {
+    return false;
+  }
+
+  if (
+    shouldPausePlaybackForCustomAction ||
+    !currentStepHasSpeakableElement ||
+    shouldBlockPlaybackForInteraction
+  ) {
+    return false;
+  }
+
+  return !hasCompletedCurrentStepAudio;
 };

--- a/src/components/Slide/utils/subtitleCue.test.ts
+++ b/src/components/Slide/utils/subtitleCue.test.ts
@@ -311,6 +311,65 @@ describe("getSubtitleCueJumpTarget", () => {
     });
   });
 
+  it("continues to the previous audio track when the previous target was already selected", () => {
+    expect(
+      getSubtitleCueJumpTarget({
+        tracks,
+        currentAudioIndex: 1,
+        currentTimeMs: 1_200,
+        direction: "previous",
+        excludeTarget: {
+          audioIndex: 1,
+          timeMs: 0,
+        },
+      })
+    ).toEqual({
+      audioIndex: 0,
+      timeMs: 2_000,
+    });
+  });
+
+  it("continues to the previous cue in the same audio track when a repeated target is excluded", () => {
+    expect(
+      getSubtitleCueJumpTarget({
+        tracks: [
+          {
+            subtitleCues: [
+              {
+                text: "Opening",
+                start_ms: 0,
+                end_ms: 1_000,
+                segment_index: 0,
+              },
+              {
+                text: "Middle",
+                start_ms: 2_000,
+                end_ms: 3_000,
+                segment_index: 1,
+              },
+              {
+                text: "Closing",
+                start_ms: 4_000,
+                end_ms: 5_000,
+                segment_index: 2,
+              },
+            ],
+          },
+        ],
+        currentAudioIndex: 0,
+        currentTimeMs: 4_500,
+        direction: "previous",
+        excludeTarget: {
+          audioIndex: 0,
+          timeMs: 2_000,
+        },
+      })
+    ).toEqual({
+      audioIndex: 0,
+      timeMs: 0,
+    });
+  });
+
   it("returns null when no subtitle target exists across tracks", () => {
     expect(
       getSubtitleCueJumpTarget({

--- a/src/components/Slide/utils/subtitleCue.test.ts
+++ b/src/components/Slide/utils/subtitleCue.test.ts
@@ -4,6 +4,7 @@ import {
   getSubtitleCueJumpTarget,
   getSubtitleCueJumpTime,
   getVisibleSubtitleText,
+  shouldClearSubtitleCueJumpTarget,
 } from "./subtitleCue";
 
 describe("getVisibleSubtitleText", () => {
@@ -409,5 +410,56 @@ describe("getSubtitleCueJumpTarget", () => {
       audioIndex: 1,
       timeMs: 4_000,
     });
+  });
+});
+
+describe("shouldClearSubtitleCueJumpTarget", () => {
+  it("keeps the target while playback is still at the subtitle jump target", () => {
+    expect(
+      shouldClearSubtitleCueJumpTarget({
+        currentAudioIndex: 0,
+        currentTimeMs: 2_000,
+        target: {
+          audioIndex: 0,
+          timeMs: 2_000,
+        },
+      })
+    ).toBe(false);
+  });
+
+  it("clears the target after playback advances away from it on the same audio", () => {
+    expect(
+      shouldClearSubtitleCueJumpTarget({
+        currentAudioIndex: 0,
+        currentTimeMs: 4_500,
+        target: {
+          audioIndex: 0,
+          timeMs: 2_000,
+        },
+      })
+    ).toBe(true);
+  });
+
+  it("keeps the target while a cross-audio subtitle jump is waiting for the target audio", () => {
+    expect(
+      shouldClearSubtitleCueJumpTarget({
+        currentAudioIndex: 1,
+        currentTimeMs: 0,
+        target: {
+          audioIndex: 0,
+          timeMs: 2_000,
+        },
+      })
+    ).toBe(false);
+  });
+
+  it("ignores missing targets", () => {
+    expect(
+      shouldClearSubtitleCueJumpTarget({
+        currentAudioIndex: 0,
+        currentTimeMs: 4_500,
+        target: null,
+      })
+    ).toBe(false);
   });
 });

--- a/src/components/Slide/utils/subtitleCue.ts
+++ b/src/components/Slide/utils/subtitleCue.ts
@@ -141,6 +141,13 @@ const getLastSubtitleCueStartTimeMs = (subtitleCues: ElementSubtitleCue[]) => {
   return lastSubtitleCue ? getSubtitleCueStartTimeMs(lastSubtitleCue) : null;
 };
 
+const isSameSubtitleCueJumpTarget = (
+  previousTarget: SubtitleCueJumpTarget | null | undefined,
+  nextTarget: SubtitleCueJumpTarget
+) =>
+  previousTarget?.audioIndex === nextTarget.audioIndex &&
+  previousTarget.timeMs === nextTarget.timeMs;
+
 /** Options used to resolve a subtitle cue jump target. */
 export interface GetSubtitleCueJumpTimeOptions {
   currentTimeMs: number;
@@ -183,6 +190,7 @@ export interface GetSubtitleCueJumpTargetOptions {
   currentAudioIndex: number;
   currentTimeMs: number;
   direction: SubtitleCueJumpDirection;
+  excludeTarget?: SubtitleCueJumpTarget | null;
   tracks?: SubtitleCueJumpTrack[];
 }
 
@@ -190,6 +198,7 @@ export const getSubtitleCueJumpTarget = ({
   currentAudioIndex,
   currentTimeMs,
   direction,
+  excludeTarget = null,
   tracks = [],
 }: GetSubtitleCueJumpTargetOptions): SubtitleCueJumpTarget | null => {
   if (
@@ -220,10 +229,28 @@ export const getSubtitleCueJumpTarget = ({
           : getFirstSubtitleCueStartTimeMs(sortedSubtitleCues);
 
       if (timeMs !== null) {
-        return {
+        const target = {
           audioIndex,
           timeMs,
         };
+
+        if (isSameSubtitleCueJumpTarget(excludeTarget, target)) {
+          const nextTimeMs = getNextSubtitleCueStartTimeMs(
+            sortedSubtitleCues,
+            timeMs
+          );
+
+          if (nextTimeMs !== null) {
+            return {
+              audioIndex,
+              timeMs: nextTimeMs,
+            };
+          }
+
+          continue;
+        }
+
+        return target;
       }
     }
 
@@ -244,10 +271,28 @@ export const getSubtitleCueJumpTarget = ({
         : getLastSubtitleCueStartTimeMs(sortedSubtitleCues);
 
     if (timeMs !== null) {
-      return {
+      const target = {
         audioIndex,
         timeMs,
       };
+
+      if (isSameSubtitleCueJumpTarget(excludeTarget, target)) {
+        const previousTimeMs = getPreviousSubtitleCueStartTimeMs(
+          sortedSubtitleCues,
+          timeMs
+        );
+
+        if (previousTimeMs !== null) {
+          return {
+            audioIndex,
+            timeMs: previousTimeMs,
+          };
+        }
+
+        continue;
+      }
+
+      return target;
     }
   }
 

--- a/src/components/Slide/utils/subtitleCue.ts
+++ b/src/components/Slide/utils/subtitleCue.ts
@@ -12,6 +12,12 @@ export interface SubtitleCueJumpTarget {
   timeMs: number;
 }
 
+export interface ShouldClearSubtitleCueJumpTargetOptions {
+  currentAudioIndex: number;
+  currentTimeMs: number;
+  target: SubtitleCueJumpTarget | null | undefined;
+}
+
 const normalizePlaybackTimeMs = (timeMs: number) => {
   const parsedTimeMs = Number(timeMs);
 
@@ -147,6 +153,17 @@ const isSameSubtitleCueJumpTarget = (
 ) =>
   previousTarget?.audioIndex === nextTarget.audioIndex &&
   previousTarget.timeMs === nextTarget.timeMs;
+
+export const shouldClearSubtitleCueJumpTarget = ({
+  currentAudioIndex,
+  currentTimeMs,
+  target,
+}: ShouldClearSubtitleCueJumpTargetOptions) =>
+  Boolean(
+    target &&
+      target.audioIndex === currentAudioIndex &&
+      target.timeMs !== normalizePlaybackTimeMs(currentTimeMs)
+  );
 
 const resolveSubtitleCueJumpTargetCandidate = ({
   audioIndex,

--- a/src/components/Slide/utils/subtitleCue.ts
+++ b/src/components/Slide/utils/subtitleCue.ts
@@ -148,6 +148,45 @@ const isSameSubtitleCueJumpTarget = (
   previousTarget?.audioIndex === nextTarget.audioIndex &&
   previousTarget.timeMs === nextTarget.timeMs;
 
+const resolveSubtitleCueJumpTargetCandidate = ({
+  audioIndex,
+  excludeTarget,
+  getFallbackTimeMs,
+  sortedSubtitleCues,
+  timeMs,
+}: {
+  audioIndex: number;
+  excludeTarget: SubtitleCueJumpTarget | null;
+  getFallbackTimeMs: (
+    subtitleCues: ElementSubtitleCue[],
+    timeMs: number
+  ) => number | null;
+  sortedSubtitleCues: ElementSubtitleCue[];
+  timeMs: number | null;
+}): SubtitleCueJumpTarget | null => {
+  if (timeMs === null) {
+    return null;
+  }
+
+  const target = {
+    audioIndex,
+    timeMs,
+  };
+
+  if (!isSameSubtitleCueJumpTarget(excludeTarget, target)) {
+    return target;
+  }
+
+  const fallbackTimeMs = getFallbackTimeMs(sortedSubtitleCues, timeMs);
+
+  return fallbackTimeMs !== null
+    ? {
+        audioIndex,
+        timeMs: fallbackTimeMs,
+      }
+    : null;
+};
+
 /** Options used to resolve a subtitle cue jump target. */
 export interface GetSubtitleCueJumpTimeOptions {
   currentTimeMs: number;
@@ -194,6 +233,84 @@ export interface GetSubtitleCueJumpTargetOptions {
   tracks?: SubtitleCueJumpTrack[];
 }
 
+const getNextSubtitleCueJumpTarget = ({
+  currentAudioIndex,
+  currentTimeMs,
+  excludeTarget,
+  tracks,
+}: {
+  currentAudioIndex: number;
+  currentTimeMs: number;
+  excludeTarget: SubtitleCueJumpTarget | null;
+  tracks: SubtitleCueJumpTrack[];
+}) => {
+  for (
+    let audioIndex = currentAudioIndex;
+    audioIndex < tracks.length;
+    audioIndex += 1
+  ) {
+    const sortedSubtitleCues = sortSubtitleCuesByPlaybackTime(
+      tracks[audioIndex]?.subtitleCues ?? []
+    );
+    const timeMs =
+      audioIndex === currentAudioIndex
+        ? getNextSubtitleCueStartTimeMs(sortedSubtitleCues, currentTimeMs)
+        : getFirstSubtitleCueStartTimeMs(sortedSubtitleCues);
+    const target = resolveSubtitleCueJumpTargetCandidate({
+      audioIndex,
+      excludeTarget,
+      getFallbackTimeMs: getNextSubtitleCueStartTimeMs,
+      sortedSubtitleCues,
+      timeMs,
+    });
+
+    if (target) {
+      return target;
+    }
+  }
+
+  return null;
+};
+
+const getPreviousSubtitleCueJumpTarget = ({
+  currentAudioIndex,
+  currentTimeMs,
+  excludeTarget,
+  tracks,
+}: {
+  currentAudioIndex: number;
+  currentTimeMs: number;
+  excludeTarget: SubtitleCueJumpTarget | null;
+  tracks: SubtitleCueJumpTrack[];
+}) => {
+  for (let audioIndex = currentAudioIndex; audioIndex >= 0; audioIndex -= 1) {
+    const sortedSubtitleCues = sortSubtitleCuesByPlaybackTime(
+      tracks[audioIndex]?.subtitleCues ?? []
+    );
+    const timeMs =
+      audioIndex === currentAudioIndex
+        ? getSubtitleCueJumpTime({
+            currentTimeMs,
+            direction: "previous",
+            subtitleCues: sortedSubtitleCues,
+          })
+        : getLastSubtitleCueStartTimeMs(sortedSubtitleCues);
+    const target = resolveSubtitleCueJumpTargetCandidate({
+      audioIndex,
+      excludeTarget,
+      getFallbackTimeMs: getPreviousSubtitleCueStartTimeMs,
+      sortedSubtitleCues,
+      timeMs,
+    });
+
+    if (target) {
+      return target;
+    }
+  }
+
+  return null;
+};
+
 export const getSubtitleCueJumpTarget = ({
   currentAudioIndex,
   currentTimeMs,
@@ -212,89 +329,18 @@ export const getSubtitleCueJumpTarget = ({
   const normalizedCurrentTimeMs = normalizePlaybackTimeMs(currentTimeMs);
 
   if (direction === "next") {
-    for (
-      let audioIndex = currentAudioIndex;
-      audioIndex < tracks.length;
-      audioIndex += 1
-    ) {
-      const sortedSubtitleCues = sortSubtitleCuesByPlaybackTime(
-        tracks[audioIndex]?.subtitleCues ?? []
-      );
-      const timeMs =
-        audioIndex === currentAudioIndex
-          ? getNextSubtitleCueStartTimeMs(
-              sortedSubtitleCues,
-              normalizedCurrentTimeMs
-            )
-          : getFirstSubtitleCueStartTimeMs(sortedSubtitleCues);
-
-      if (timeMs !== null) {
-        const target = {
-          audioIndex,
-          timeMs,
-        };
-
-        if (isSameSubtitleCueJumpTarget(excludeTarget, target)) {
-          const nextTimeMs = getNextSubtitleCueStartTimeMs(
-            sortedSubtitleCues,
-            timeMs
-          );
-
-          if (nextTimeMs !== null) {
-            return {
-              audioIndex,
-              timeMs: nextTimeMs,
-            };
-          }
-
-          continue;
-        }
-
-        return target;
-      }
-    }
-
-    return null;
+    return getNextSubtitleCueJumpTarget({
+      currentAudioIndex,
+      currentTimeMs: normalizedCurrentTimeMs,
+      excludeTarget,
+      tracks,
+    });
   }
 
-  for (let audioIndex = currentAudioIndex; audioIndex >= 0; audioIndex -= 1) {
-    const sortedSubtitleCues = sortSubtitleCuesByPlaybackTime(
-      tracks[audioIndex]?.subtitleCues ?? []
-    );
-    const timeMs =
-      audioIndex === currentAudioIndex
-        ? getSubtitleCueJumpTime({
-            currentTimeMs: normalizedCurrentTimeMs,
-            direction,
-            subtitleCues: sortedSubtitleCues,
-          })
-        : getLastSubtitleCueStartTimeMs(sortedSubtitleCues);
-
-    if (timeMs !== null) {
-      const target = {
-        audioIndex,
-        timeMs,
-      };
-
-      if (isSameSubtitleCueJumpTarget(excludeTarget, target)) {
-        const previousTimeMs = getPreviousSubtitleCueStartTimeMs(
-          sortedSubtitleCues,
-          timeMs
-        );
-
-        if (previousTimeMs !== null) {
-          return {
-            audioIndex,
-            timeMs: previousTimeMs,
-          };
-        }
-
-        continue;
-      }
-
-      return target;
-    }
-  }
-
-  return null;
+  return getPreviousSubtitleCueJumpTarget({
+    currentAudioIndex,
+    currentTimeMs: normalizedCurrentTimeMs,
+    excludeTarget,
+    tracks,
+  });
 };

--- a/src/components/Slide/utils/subtitleCue.ts
+++ b/src/components/Slide/utils/subtitleCue.ts
@@ -159,11 +159,8 @@ export const shouldClearSubtitleCueJumpTarget = ({
   currentTimeMs,
   target,
 }: ShouldClearSubtitleCueJumpTargetOptions) =>
-  Boolean(
-    target &&
-      target.audioIndex === currentAudioIndex &&
-      target.timeMs !== normalizePlaybackTimeMs(currentTimeMs)
-  );
+  target?.audioIndex === currentAudioIndex &&
+  target.timeMs !== normalizePlaybackTimeMs(currentTimeMs);
 
 const resolveSubtitleCueJumpTargetCandidate = ({
   audioIndex,


### PR DESCRIPTION
## Summary
- Prevent the default slide audio startup effect from overwriting a pending cross-page subtitle jump target.
- Add focused playback sequence coverage for the subtitle-jump handoff case.

## Tests
- pnpm exec vitest run --project unit src/components/Slide/utils/playbackSequence.test.ts src/components/Slide/utils/subtitleCue.test.ts src/components/Slide/utils/subtitleJumpNavigation.test.ts
- npm run lint
- npm run build
- git diff --check

Note: npm run build exits 0 but still prints existing vite:dts type diagnostics outside the files changed in this PR.