### PR TITLE
chore: release markdown-flow-ui 0.1.129

### DIFF
--- a/.github/workflows/publish-manual.yml
+++ b/.github/workflows/publish-manual.yml
@@ -59,9 +59,9 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
 
-      # Trusted Publishing (OIDC) requires npm >= 11.5.1; node 20 ships an older npm.
+      # Trusted Publishing (OIDC) requires npm >= 11.5.1; npm 12 requires Node 22+.
       - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.6.4
 
       # The build runs `pnpm exec tailwindcss` (build:css); pnpm is not preinstalled.
       - name: Install pnpm

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-flow-ui",
-  "version": "0.1.128",
+  "version": "0.1.129",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-flow-ui",
-      "version": "0.1.128",
+      "version": "0.1.129",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
       ]
     }
   },
-  "version": "0.1.128",
+  "version": "0.1.129",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
Published markdown-flow-ui@0.1.129 via the manual publish workflow. Also pins the workflow npm upgrade to 11.6.4 so Node 20 release runs avoid the npm 12 engine mismatch.

Action: https://github.com/ai-shifu/markdown-flow-ui/actions/runs/28988724740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release version to **0.1.129**.
  * Adjusted the publishing workflow to use a specific npm version for more reliable package publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->