### PR TITLE
fix: keep slide player controls visible on hover

### DIFF
--- a/src/components/Slide/Player.tsx
+++ b/src/components/Slide/Player.tsx
@@ -228,7 +228,9 @@ export type PlayerProps = Omit<React.ComponentProps<"div">, "onEnded"> & {
   prevDisabled?: boolean;
   nextDisabled?: boolean;
   showControls?: boolean;
+  /** Fired when the pointer enters the controls container to pause auto-hide. */
   onControlsPointerEnter?: React.PointerEventHandler<HTMLDivElement>;
+  /** Fired when the pointer leaves the controls container to resume auto-hide. */
   onControlsPointerLeave?: React.PointerEventHandler<HTMLDivElement>;
   /**
    * Enables document-level keyboard shortcuts for existing player actions.

--- a/src/components/Slide/Player.tsx
+++ b/src/components/Slide/Player.tsx
@@ -228,6 +228,8 @@ export type PlayerProps = Omit<React.ComponentProps<"div">, "onEnded"> & {
   prevDisabled?: boolean;
   nextDisabled?: boolean;
   showControls?: boolean;
+  onControlsPointerEnter?: React.PointerEventHandler<HTMLDivElement>;
+  onControlsPointerLeave?: React.PointerEventHandler<HTMLDivElement>;
   /**
    * Enables document-level keyboard shortcuts for existing player actions.
    *
@@ -326,6 +328,8 @@ const Player = ({
   prevDisabled = false,
   nextDisabled = false,
   showControls = true,
+  onControlsPointerEnter,
+  onControlsPointerLeave,
   enableKeyboardShortcuts = true,
   subtitleSeekRequest = null,
   customActions,
@@ -1914,7 +1918,12 @@ const Player = ({
             viewMode={mobileViewMode}
           />
 
-          <div className="slide-player__controls" style={controlsStyle}>
+          <div
+            className="slide-player__controls"
+            onPointerEnter={onControlsPointerEnter}
+            onPointerLeave={onControlsPointerLeave}
+            style={controlsStyle}
+          >
             <div className="slide-player__group">
               <button
                 aria-expanded={isMobileMoreOpen}

--- a/src/components/Slide/Slide.stories.tsx
+++ b/src/components/Slide/Slide.stories.tsx
@@ -68,7 +68,8 @@ const meta = {
     },
     playerAutoHideDelay: {
       control: { type: "number", min: 0, step: 500 },
-      description: "Auto-hide delay for player controls in milliseconds",
+      description:
+        "Auto-hide delay for player controls in milliseconds after the pointer leaves the control bar",
     },
     markerAutoAdvanceDelay: {
       control: { type: "number", min: 0, step: 500 },

--- a/src/components/Slide/Slide.tsx
+++ b/src/components/Slide/Slide.tsx
@@ -269,6 +269,7 @@ const Slide: React.FC<SlideProps> = ({
   const stageLayerRef = useRef<HTMLDivElement | null>(null);
   const lastElementRef = useRef<HTMLDivElement | null>(null);
   const playerHideTimerRef = useRef<number | null>(null);
+  const isPointerInsidePlayerControlsRef = useRef(false);
   const autoAdvanceTimerRef = useRef<number | null>(null);
   const interactionAutoCloseTimerRef = useRef<number | null>(null);
   const interactionOverlayOpenTimerRef = useRef<number | null>(null);
@@ -729,6 +730,15 @@ const Slide: React.FC<SlideProps> = ({
     [clearInteractionOverlayOpenTimer]
   );
 
+  const isPlayerControlsHovered = useCallback(
+    () =>
+      isPointerInsidePlayerControlsRef.current ||
+      Boolean(
+        sectionRef.current?.querySelector(".slide-player__controls:hover")
+      ),
+    []
+  );
+
   const showPlayerControls = useCallback(
     (enableAutoHide = hasPlayerInteracted) => {
       if (!shouldRenderPlayer) {
@@ -738,11 +748,21 @@ const Slide: React.FC<SlideProps> = ({
       setIsPlayerVisible(true);
       clearPlayerHideTimer();
 
-      if (playerAlwaysVisible || !enableAutoHide || playerAutoHideDelay <= 0) {
+      if (
+        playerAlwaysVisible ||
+        !enableAutoHide ||
+        playerAutoHideDelay <= 0 ||
+        isPlayerControlsHovered()
+      ) {
         return;
       }
 
       playerHideTimerRef.current = window.setTimeout(() => {
+        if (isPlayerControlsHovered()) {
+          playerHideTimerRef.current = null;
+          return;
+        }
+
         setIsPlayerVisible(false);
         playerHideTimerRef.current = null;
       }, playerAutoHideDelay);
@@ -750,6 +770,7 @@ const Slide: React.FC<SlideProps> = ({
     [
       clearPlayerHideTimer,
       hasPlayerInteracted,
+      isPlayerControlsHovered,
       playerAlwaysVisible,
       playerAutoHideDelay,
       shouldRenderPlayer,
@@ -807,6 +828,14 @@ const Slide: React.FC<SlideProps> = ({
       onPlayerVisibilityChange?.(false);
     };
   }, [onPlayerVisibilityChange, playerVisible]);
+
+  useEffect(() => {
+    if (playerVisible) {
+      return;
+    }
+
+    isPointerInsidePlayerControlsRef.current = false;
+  }, [playerVisible]);
 
   useEffect(() => {
     if (isMobileDevice || mobileViewMode === DEFAULT_MOBILE_VIEW_MODE) {
@@ -1681,6 +1710,20 @@ const Slide: React.FC<SlideProps> = ({
     setIsInteractionOverlayOpen((prevOpen) => !prevOpen);
   }, [activeInteractionElement]);
 
+  const handlePlayerControlsPointerEnter = useCallback(() => {
+    isPointerInsidePlayerControlsRef.current = true;
+    clearPlayerHideTimer();
+
+    if (shouldRenderPlayer) {
+      setIsPlayerVisible(true);
+    }
+  }, [clearPlayerHideTimer, shouldRenderPlayer]);
+
+  const handlePlayerControlsPointerLeave = useCallback(() => {
+    isPointerInsidePlayerControlsRef.current = false;
+    showPlayerControls(true);
+  }, [showPlayerControls]);
+
   const stopOverlayPropagation = useCallback(
     (
       event:
@@ -1974,6 +2017,8 @@ const Slide: React.FC<SlideProps> = ({
               mobileViewMode={effectiveMobileViewMode}
               settingsPortalContainer={viewportRef.current}
               onMobileViewModeChange={handleMobileViewModeSelect}
+              onControlsPointerEnter={handlePlayerControlsPointerEnter}
+              onControlsPointerLeave={handlePlayerControlsPointerLeave}
               onInteractionToggle={handleInteractionToggle}
               onNext={handleNext}
               onPrev={handlePrev}


### PR DESCRIPTION
## Summary
- Keep slide player controls visible while the pointer is over the control bar.
- Restart the configured auto-hide delay only after the pointer leaves the control bar.
- Update the Storybook arg description for `playerAutoHideDelay`.

## Root Cause
The auto-hide timer was scheduled without checking whether the pointer was currently over the player controls, so the controls could disappear while the user was trying to interact with them.

## Verification
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run typecheck:exports`
- `npm run build` (exits 0; existing `vite:dts` diagnostics are still printed)
- Storybook + Playwright: controls remained visible while hovered past the configured delay, then hid after the pointer left and the delay elapsed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Player controls now stay visible while the pointer is over them, making it easier to interact without the UI hiding unexpectedly.
  * Added support for handling pointer enter/leave on the controls area.

* **Bug Fixes**
  * Improved the auto-hide behavior so controls won’t disappear mid-hover and recheck hover state before hiding.
  * Reset control hover state when the player is no longer visible.

* **Documentation**
  * Clarified the Storybook description for the player controls auto-hide delay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->