### PR TITLE
feat: separate slide player visibility controls

### DIFF
--- a/src/components/Slide/Player.tsx
+++ b/src/components/Slide/Player.tsx
@@ -203,6 +203,7 @@ export type PlayerProps = Omit<React.ComponentProps<"div">, "onEnded"> & {
   isSubtitleEnabled?: boolean;
   prevDisabled?: boolean;
   nextDisabled?: boolean;
+  /** Shows or hides the visual controls without disabling audio, callbacks, or keyboard shortcuts. */
   showControls?: boolean;
   /** Fired when the pointer enters the controls container to pause auto-hide. */
   onControlsPointerEnter?: React.PointerEventHandler<HTMLDivElement>;

--- a/src/components/Slide/Slide.stories.tsx
+++ b/src/components/Slide/Slide.stories.tsx
@@ -92,10 +92,6 @@ const meta = {
       description:
         "Auto-advance delay for silent marker-only steps in milliseconds",
     },
-    playerAlwaysVisible: {
-      control: "boolean",
-      description: 'Deprecated: use playerControlsVisibility="visible" instead',
-    },
     playerCustomActions: {
       control: false,
       description:
@@ -118,7 +114,6 @@ const meta = {
     fullscreenHeader: undefined,
     playerAutoHideDelay: 3000,
     markerAutoAdvanceDelay: 2000,
-    playerAlwaysVisible: false,
   },
 } satisfies Meta<typeof Slide>;
 
@@ -2314,7 +2309,7 @@ export const ControlsAutoHide: Story = {
 export const FrenchLocale: Story = {
   args: {
     locale: "fr-FR",
-    playerAlwaysVisible: true,
+    playerControlsVisibility: "visible",
     interactionTexts: undefined,
     playerTexts: undefined,
     elementList: [
@@ -2340,7 +2335,7 @@ export const FrenchLocale: Story = {
 
 export const CustomPlayerActionButton: Story = {
   args: {
-    playerAlwaysVisible: true,
+    playerControlsVisibility: "visible",
     elementList: [
       {
         sequence_number: 90,
@@ -2759,7 +2754,6 @@ export const FullViewportSlides: Story = {
 
 export const FullViewportSingleSlide: Story = {
   args: {
-    playerAlwaysVisible: false,
     elementList: [
       {
         sequence_number: 31,
@@ -3272,7 +3266,6 @@ export const FullViewportSingleSlideWithEmptyPpt: Story = {
 export const StuckSpeakableFixtureSSE: Story = {
   args: {
     bufferingText: "Audio buffering...",
-    playerAlwaysVisible: false,
   },
   parameters: {
     docs: {
@@ -3295,7 +3288,6 @@ export const StuckSpeakableFixtureSSE: Story = {
 
 export const HistorySlides: Story = {
   args: {
-    // playerAlwaysVisible: true,
     fullscreenHeader: {
       content: (
         <div className="flex min-w-0 items-center gap-2 overflow-hidden text-[16px] font-bold leading-6 text-black">
@@ -3595,7 +3587,6 @@ export const HistorySlides: Story = {
 
 export const StreamingSingleIframeSlide: Story = {
   args: {
-    playerAlwaysVisible: false,
     elementList: [
       createExampleElement({
         sequenceNumber: 1,
@@ -3623,7 +3614,6 @@ export const StreamingSingleIframeSlide: Story = {
 export const StreamingSpeakableLoadingOnlySlide: Story = {
   args: {
     bufferingText: "Audio buffering...",
-    playerAlwaysVisible: false,
     elementList: [
       createExampleElement({
         sequenceNumber: 1,
@@ -3746,7 +3736,6 @@ export const FullViewportSingleSlideWithSSE: Story = {
 
 export const HistoryInteractionTriggeredSSE: Story = {
   args: {
-    playerAlwaysVisible: false,
     interactionDefaultValueOptions: {
       resolveDefaultValues: () => ({
         selectedValues: ["都不同意"],
@@ -3780,7 +3769,6 @@ export const HistoryInteractionTriggeredSSE: Story = {
 
 export const InteractionTriggeredFixtureSwitchSSE: Story = {
   args: {
-    playerAlwaysVisible: false,
     interactionDefaultValueOptions: {
       resolveDefaultValues: () => ({
         selectedValues: ["非常了解"],
@@ -4119,7 +4107,6 @@ const delayedAudioSourceElement =
 export const StreamingSpeakableDelayedAudioSlide: Story = {
   args: {
     bufferingText: "Audio buffering...",
-    playerAlwaysVisible: false,
     elementList: [
       createExampleElement({
         sequenceNumber: 1,

--- a/src/components/Slide/Slide.stories.tsx
+++ b/src/components/Slide/Slide.stories.tsx
@@ -71,6 +71,17 @@ const meta = {
       description:
         "Fullscreen-only mobile header with a built-in back button and optional custom content slot",
     },
+    playerEnabled: {
+      control: "boolean",
+      description:
+        "Enable the player runtime, including audio playback and keyboard shortcuts",
+    },
+    playerControlsVisibility: {
+      control: "select",
+      options: ["auto", "visible", "hidden"],
+      description:
+        "Control whether player controls auto-hide, stay visible, or stay hidden while runtime behavior remains active",
+    },
     playerAutoHideDelay: {
       control: { type: "number", min: 0, step: 500 },
       description:
@@ -83,7 +94,7 @@ const meta = {
     },
     playerAlwaysVisible: {
       control: "boolean",
-      description: "Keep the player controls visible without auto hiding",
+      description: 'Deprecated: use playerControlsVisibility="visible" instead',
     },
     playerCustomActions: {
       control: false,
@@ -2267,6 +2278,36 @@ const CUSTOM_PLAYER_SECOND_QUIZ_SUBTITLE_CUES = createCustomPlayerSubtitleCues(
 export const Default: Story = {
   args: {
     elementList: exampleElementList,
+  },
+};
+
+export const PlayerDisabled: Story = {
+  args: {
+    elementList: exampleElementList,
+    playerEnabled: false,
+  },
+};
+
+export const ControlsHiddenWithKeyboardShortcuts: Story = {
+  args: {
+    elementList: exampleElementList,
+    enableKeyboardShortcuts: true,
+    playerControlsVisibility: "hidden",
+  },
+};
+
+export const ControlsAlwaysVisible: Story = {
+  args: {
+    elementList: exampleElementList,
+    playerControlsVisibility: "visible",
+  },
+};
+
+export const ControlsAutoHide: Story = {
+  args: {
+    elementList: exampleElementList,
+    playerAutoHideDelay: 3000,
+    playerControlsVisibility: "auto",
   },
 };
 

--- a/src/components/Slide/Slide.tsx
+++ b/src/components/Slide/Slide.tsx
@@ -1045,6 +1045,11 @@ const Slide: React.FC<SlideProps> = ({
   });
 
   useEffect(() => {
+    if (!shouldMountPlayer) {
+      resetAudioSequence();
+      return;
+    }
+
     const { hasPlaybackContextChanged, shouldInitializeAudioSequence } =
       getPlaybackSequenceTransition({
         previousResetKey: playbackResetKeyRef.current,
@@ -1178,6 +1183,7 @@ const Slide: React.FC<SlideProps> = ({
     resetAudioSequence,
     requestSubtitleCueSeek,
     scheduleInteractionOverlayOpen,
+    shouldMountPlayer,
     slideElementList,
     startCurrentAudioSequence,
     shouldPausePlaybackForCustomAction,

--- a/src/components/Slide/Slide.tsx
+++ b/src/components/Slide/Slide.tsx
@@ -65,6 +65,10 @@ import {
 import { createPlaybackTimeStore } from "./utils/playbackTimeStore";
 import { shouldUseAutoAdvanceToggle } from "./utils/playerToggleMode";
 import {
+  resolveSlidePlayerVisibility,
+  type SlidePlayerControlsVisibility,
+} from "./utils/playerVisibility";
+import {
   DEFAULT_SLIDE_BUFFERING_TEXTS,
   getSlideLocaleTexts,
   type SlideBufferingReason,
@@ -77,6 +81,7 @@ export type {
   SlidePlayerCustomActionContext,
   SlidePlayerCustomActions,
 } from "./types";
+export type { SlidePlayerControlsVisibility } from "./utils/playerVisibility";
 
 const DEFAULT_MARKER_AUTO_ADVANCE_DELAY_MS = 2000;
 const DEFAULT_INTERACTION_OVERLAY_OPEN_DELAY_MS = 300;
@@ -221,7 +226,23 @@ export interface SlideProps extends React.ComponentProps<"section"> {
   elementList?: Element[];
   /** Locale used for built-in UI text when a more specific text prop is not provided. */
   locale?: MarkdownFlowLocale;
+  /** Enables the player runtime, including audio playback and keyboard shortcuts. */
+  playerEnabled?: boolean;
+  /** @deprecated Use playerEnabled instead. */
   showPlayer?: boolean;
+  /**
+   * Controls whether the player controls are always visible, always hidden, or auto-hidden.
+   *
+   * Use `"hidden"` to keep audio playback and keyboard shortcuts active while
+   * hiding the visual controls.
+   *
+   * @example
+   * ```tsx
+   * <Slide playerControlsVisibility="hidden" enableKeyboardShortcuts />
+   * ```
+   */
+  playerControlsVisibility?: SlidePlayerControlsVisibility;
+  /** @deprecated Use playerControlsVisibility="visible" instead. */
   playerAlwaysVisible?: boolean;
   playerClassName?: string;
   fullscreenHeader?: SlideFullscreenHeader;
@@ -258,7 +279,9 @@ export interface SlideProps extends React.ComponentProps<"section"> {
 const Slide: React.FC<SlideProps> = ({
   elementList = [],
   locale,
+  playerEnabled,
   showPlayer = true,
+  playerControlsVisibility,
   playerAlwaysVisible = false,
   playerClassName,
   fullscreenHeader,
@@ -292,6 +315,15 @@ const Slide: React.FC<SlideProps> = ({
       ),
     [bufferingText, localeTexts.bufferingText]
   );
+  const {
+    playerEnabled: resolvedPlayerEnabled,
+    playerControlsVisibility: resolvedPlayerControlsVisibility,
+  } = resolveSlidePlayerVisibility({
+    playerEnabled,
+    showPlayer,
+    playerControlsVisibility,
+    playerAlwaysVisible,
+  });
   const keyboardShortcutOwnerId = useId();
   const sectionRef = useRef<HTMLElement | null>(null);
   const viewportRef = useRef<HTMLDivElement | null>(null);
@@ -347,8 +379,8 @@ const Slide: React.FC<SlideProps> = ({
     (element) => element.is_renderable !== false
   ).length;
   const isSingleSlide = visibleMarkerCount === 1;
-  const shouldRenderPlayer =
-    showPlayer &&
+  const shouldMountPlayer =
+    resolvedPlayerEnabled &&
     (slideElementList.length > 0 ||
       audioList.length > 0 ||
       Boolean(currentInteractionElement));
@@ -360,12 +392,12 @@ const Slide: React.FC<SlideProps> = ({
     [enableKeyboardShortcuts, keyboardShortcutOwnerId]
   );
   const activateKeyboardShortcutOwner = useCallback(() => {
-    if (!enableKeyboardShortcuts || !shouldRenderPlayer) {
+    if (!enableKeyboardShortcuts || !shouldMountPlayer) {
       return;
     }
 
     activatePlayerKeyboardShortcutOwner(keyboardShortcutOwnerId);
-  }, [enableKeyboardShortcuts, keyboardShortcutOwnerId, shouldRenderPlayer]);
+  }, [enableKeyboardShortcuts, keyboardShortcutOwnerId, shouldMountPlayer]);
   const currentAudioSequenceKeys = useMemo(
     () =>
       currentAudioSequenceIndexes
@@ -431,12 +463,14 @@ const Slide: React.FC<SlideProps> = ({
     ]
   );
   const previousEffectiveMobileViewModeRef = useRef(effectiveMobileViewMode);
-  const playerVisible =
-    shouldRenderPlayer && (playerAlwaysVisible || isPlayerVisible);
+  const playerControlsVisible =
+    shouldMountPlayer &&
+    resolvedPlayerControlsVisibility !== "hidden" &&
+    (resolvedPlayerControlsVisibility === "visible" || isPlayerVisible);
   const shouldShowFullscreenHeader =
-    isImmersiveMobileFullscreen && playerVisible;
+    isImmersiveMobileFullscreen && playerControlsVisible;
   const shouldApplyFullscreenViewportPadding =
-    isImmersiveMobileFullscreen && playerVisible;
+    isImmersiveMobileFullscreen && playerControlsVisible;
   const shouldShowMobileFullscreenMask =
     isImmersiveMobileFullscreen || isNativeMobileFullscreen;
   const isDesktopBrowserFullscreen = isBrowserFullscreen && !isMobileDevice;
@@ -768,9 +802,9 @@ const Slide: React.FC<SlideProps> = ({
     []
   );
 
-  const showPlayerControls = useCallback(
+  const revealPlayerControls = useCallback(
     (enableAutoHide = hasPlayerInteracted) => {
-      if (!shouldRenderPlayer) {
+      if (!shouldMountPlayer || resolvedPlayerControlsVisibility === "hidden") {
         return;
       }
 
@@ -778,7 +812,7 @@ const Slide: React.FC<SlideProps> = ({
       clearPlayerHideTimer();
 
       if (
-        playerAlwaysVisible ||
+        resolvedPlayerControlsVisibility === "visible" ||
         !enableAutoHide ||
         playerAutoHideDelay <= 0 ||
         isPlayerControlsHovered()
@@ -800,9 +834,9 @@ const Slide: React.FC<SlideProps> = ({
       clearPlayerHideTimer,
       hasPlayerInteracted,
       isPlayerControlsHovered,
-      playerAlwaysVisible,
       playerAutoHideDelay,
-      shouldRenderPlayer,
+      resolvedPlayerControlsVisibility,
+      shouldMountPlayer,
     ]
   );
 
@@ -851,20 +885,20 @@ const Slide: React.FC<SlideProps> = ({
   ]);
 
   useEffect(() => {
-    onPlayerVisibilityChange?.(playerVisible);
+    onPlayerVisibilityChange?.(playerControlsVisible);
 
     return () => {
       onPlayerVisibilityChange?.(false);
     };
-  }, [onPlayerVisibilityChange, playerVisible]);
+  }, [onPlayerVisibilityChange, playerControlsVisible]);
 
   useEffect(() => {
-    if (playerVisible) {
+    if (playerControlsVisible) {
       return;
     }
 
     isPointerInsidePlayerControlsRef.current = false;
-  }, [playerVisible]);
+  }, [playerControlsVisible]);
 
   useEffect(() => {
     if (isMobileDevice || mobileViewMode === DEFAULT_MOBILE_VIEW_MODE) {
@@ -947,13 +981,13 @@ const Slide: React.FC<SlideProps> = ({
   ]);
 
   useEffect(() => {
-    if (!shouldRenderPlayer) {
+    if (!shouldMountPlayer || resolvedPlayerControlsVisibility === "hidden") {
       clearPlayerHideTimer();
       setIsPlayerVisible(false);
       return;
     }
 
-    if (playerAlwaysVisible) {
+    if (resolvedPlayerControlsVisibility === "visible") {
       clearPlayerHideTimer();
       setIsPlayerVisible(true);
       return;
@@ -961,14 +995,14 @@ const Slide: React.FC<SlideProps> = ({
 
     if (!hasPlayerInteracted) {
       // Keep the initial player visible briefly, then hide it automatically.
-      showPlayerControls(true);
+      revealPlayerControls(true);
     }
   }, [
     clearPlayerHideTimer,
     hasPlayerInteracted,
-    playerAlwaysVisible,
-    shouldRenderPlayer,
-    showPlayerControls,
+    resolvedPlayerControlsVisibility,
+    shouldMountPlayer,
+    revealPlayerControls,
   ]);
 
   useEffect(() => {
@@ -989,14 +1023,14 @@ const Slide: React.FC<SlideProps> = ({
         return;
       }
 
-      if (!shouldRenderPlayer) {
+      if (!shouldMountPlayer) {
         return;
       }
 
       // Restore player controls on explicit click/tap without waking on scroll start.
       activateKeyboardShortcutOwner();
       setHasPlayerInteracted(true);
-      showPlayerControls(true);
+      revealPlayerControls(true);
     };
 
     window.addEventListener("message", handleSandboxInteraction);
@@ -1004,17 +1038,17 @@ const Slide: React.FC<SlideProps> = ({
     return () => {
       window.removeEventListener("message", handleSandboxInteraction);
     };
-  }, [activateKeyboardShortcutOwner, shouldRenderPlayer, showPlayerControls]);
+  }, [activateKeyboardShortcutOwner, shouldMountPlayer, revealPlayerControls]);
 
   useWakePlayerFromIframe({
     sectionRef,
-    enabled: shouldRenderPlayer,
+    enabled: shouldMountPlayer,
     keyboardShortcutsEnabled: enableKeyboardShortcuts,
     onKeyboardShortcut: activateKeyboardShortcutOwner,
     onWake: () => {
       activateKeyboardShortcutOwner();
       setHasPlayerInteracted(true);
-      showPlayerControls(true);
+      revealPlayerControls(true);
     },
   });
 
@@ -1561,7 +1595,7 @@ const Slide: React.FC<SlideProps> = ({
 
       if (shouldWakePlayerControlsAfterNavigation(context)) {
         setHasPlayerInteracted(true);
-        showPlayerControls(true);
+        revealPlayerControls(true);
       }
 
       if (targetSlideIndex === currentIndex) {
@@ -1592,7 +1626,7 @@ const Slide: React.FC<SlideProps> = ({
       goTo,
       requestSubtitleCueSeek,
       resetAudioSequence,
-      showPlayerControls,
+      revealPlayerControls,
       syncPlaybackPreferenceBeforeNavigation,
     ]
   );
@@ -1605,7 +1639,7 @@ const Slide: React.FC<SlideProps> = ({
       setIsAudioLoadingVisible(false);
       if (shouldWakePlayerControlsAfterNavigation(context)) {
         setHasPlayerInteracted(true);
-        showPlayerControls(true);
+        revealPlayerControls(true);
       }
       resetAudioSequence();
       goPrev();
@@ -1613,7 +1647,7 @@ const Slide: React.FC<SlideProps> = ({
     [
       goPrev,
       resetAudioSequence,
-      showPlayerControls,
+      revealPlayerControls,
       syncPlaybackPreferenceBeforeNavigation,
     ]
   );
@@ -1626,7 +1660,7 @@ const Slide: React.FC<SlideProps> = ({
       setIsAudioLoadingVisible(false);
       if (shouldWakePlayerControlsAfterNavigation(context)) {
         setHasPlayerInteracted(true);
-        showPlayerControls(true);
+        revealPlayerControls(true);
       }
       resetAudioSequence();
       goNext();
@@ -1634,7 +1668,7 @@ const Slide: React.FC<SlideProps> = ({
     [
       goNext,
       resetAudioSequence,
-      showPlayerControls,
+      revealPlayerControls,
       syncPlaybackPreferenceBeforeNavigation,
     ]
   );
@@ -1745,15 +1779,15 @@ const Slide: React.FC<SlideProps> = ({
     isPointerInsidePlayerControlsRef.current = true;
     clearPlayerHideTimer();
 
-    if (shouldRenderPlayer) {
+    if (shouldMountPlayer) {
       setIsPlayerVisible(true);
     }
-  }, [clearPlayerHideTimer, shouldRenderPlayer]);
+  }, [clearPlayerHideTimer, shouldMountPlayer]);
 
   const handlePlayerControlsPointerLeave = useCallback(() => {
     isPointerInsidePlayerControlsRef.current = false;
-    showPlayerControls(true);
-  }, [showPlayerControls]);
+    revealPlayerControls(true);
+  }, [revealPlayerControls]);
 
   const stopOverlayPropagation = useCallback(
     (
@@ -1764,11 +1798,11 @@ const Slide: React.FC<SlideProps> = ({
       event.stopPropagation();
 
       // Keep the player visible a bit longer when users interact with the overlay.
-      if (playerVisible) {
-        showPlayerControls(true);
+      if (playerControlsVisible) {
+        revealPlayerControls(true);
       }
     },
-    [isPlayerVisible, showPlayerControls]
+    [playerControlsVisible, revealPlayerControls]
   );
 
   const handleSurfacePointerDown = useCallback(
@@ -1789,8 +1823,8 @@ const Slide: React.FC<SlideProps> = ({
 
   const handleSurfaceClick = useCallback(() => {
     setHasPlayerInteracted(true);
-    showPlayerControls(true);
-  }, [showPlayerControls]);
+    revealPlayerControls(true);
+  }, [revealPlayerControls]);
 
   const currentRenderElementKeys = useMemo(
     () =>
@@ -1974,9 +2008,9 @@ const Slide: React.FC<SlideProps> = ({
 
         <SubtitleOverlay
           extraBottomOffset={interactionOverlaySubtitleOffset}
-          hasPlayerGap={playerVisible}
+          hasPlayerGap={playerControlsVisible}
           isEnabled={isSubtitleEnabled && hasCurrentAudioPlaybackStarted}
-          isPlayerHidden={shouldRenderPlayer && !playerVisible}
+          isPlayerHidden={shouldMountPlayer && !playerControlsVisible}
           playbackTimeStore={playbackTimeStore}
           subtitleCues={currentSubtitleCues}
         />
@@ -1987,7 +2021,7 @@ const Slide: React.FC<SlideProps> = ({
             data-player-keyboard-shortcuts-ignore="true"
             className={cn(
               "slide-interaction-overlay",
-              playerVisible && shouldRenderPlayer
+              playerControlsVisible && shouldMountPlayer
                 ? "slide-interaction-overlay--with-player"
                 : "slide-interaction-overlay--standalone"
             )}
@@ -2024,7 +2058,7 @@ const Slide: React.FC<SlideProps> = ({
           </div>
         ) : null}
 
-        {shouldRenderPlayer ? (
+        {shouldMountPlayer ? (
           <PlayerKeyboardShortcutContext.Provider
             value={keyboardShortcutContextValue}
           >
@@ -2034,7 +2068,7 @@ const Slide: React.FC<SlideProps> = ({
                 "absolute left-1/2 z-[2] -translate-x-1/2",
                 isDesktopBrowserFullscreen ? "bottom-3" : "-bottom-3",
                 playerClassName,
-                !playerVisible && "pointer-events-none opacity-0"
+                !playerControlsVisible && "pointer-events-none opacity-0"
               )}
               currentAudioIndex={currentAudioIndex}
               defaultPlaying={isPlaybackRequested}
@@ -2070,7 +2104,7 @@ const Slide: React.FC<SlideProps> = ({
               onSubtitleJump={handleSubtitleJump}
               canJumpToSubtitleTarget={canJumpToSubtitleTarget}
               prevDisabled={!canGoPrev}
-              showControls={playerVisible}
+              showControls={playerControlsVisible}
               subtitleSeekRequest={subtitleSeekRequest}
               texts={playerTexts}
               customActionContext={playerCustomActionContext}

--- a/src/components/Slide/Slide.tsx
+++ b/src/components/Slide/Slide.tsx
@@ -228,8 +228,6 @@ export interface SlideProps extends React.ComponentProps<"section"> {
   locale?: MarkdownFlowLocale;
   /** Enables the player runtime, including audio playback and keyboard shortcuts. */
   playerEnabled?: boolean;
-  /** @deprecated Use playerEnabled instead. */
-  showPlayer?: boolean;
   /**
    * Controls whether the player controls are always visible, always hidden, or auto-hidden.
    *
@@ -242,8 +240,6 @@ export interface SlideProps extends React.ComponentProps<"section"> {
    * ```
    */
   playerControlsVisibility?: SlidePlayerControlsVisibility;
-  /** @deprecated Use playerControlsVisibility="visible" instead. */
-  playerAlwaysVisible?: boolean;
   playerClassName?: string;
   fullscreenHeader?: SlideFullscreenHeader;
   playerCustomActions?: PlayerProps["customActions"];
@@ -280,9 +276,7 @@ const Slide: React.FC<SlideProps> = ({
   elementList = [],
   locale,
   playerEnabled,
-  showPlayer = true,
   playerControlsVisibility,
-  playerAlwaysVisible = false,
   playerClassName,
   fullscreenHeader,
   playerCustomActions,
@@ -320,9 +314,7 @@ const Slide: React.FC<SlideProps> = ({
     playerControlsVisibility: resolvedPlayerControlsVisibility,
   } = resolveSlidePlayerVisibility({
     playerEnabled,
-    showPlayer,
     playerControlsVisibility,
-    playerAlwaysVisible,
   });
   const keyboardShortcutOwnerId = useId();
   const sectionRef = useRef<HTMLElement | null>(null);

--- a/src/components/Slide/index.ts
+++ b/src/components/Slide/index.ts
@@ -27,6 +27,7 @@ export {
 export type {
   SlideInteractionTexts,
   SlideFullscreenHeader,
+  SlidePlayerControlsVisibility,
   SlideProps,
 } from "./Slide";
 export type {

--- a/src/components/Slide/utils/playerVisibility.test.ts
+++ b/src/components/Slide/utils/playerVisibility.test.ts
@@ -26,34 +26,14 @@ describe("resolveSlidePlayerVisibility", () => {
     });
   });
 
-  it("prefers playerControlsVisibility over playerAlwaysVisible", () => {
+  it("uses explicit always-visible controls", () => {
     expect(
       resolveSlidePlayerVisibility({
-        playerAlwaysVisible: true,
-        playerControlsVisibility: "hidden",
+        playerControlsVisibility: "visible",
       })
     ).toEqual({
       playerEnabled: true,
-      playerControlsVisibility: "hidden",
-    });
-  });
-
-  it("prefers playerEnabled over showPlayer", () => {
-    expect(
-      resolveSlidePlayerVisibility({
-        playerEnabled: true,
-        showPlayer: false,
-      })
-    ).toEqual({
-      playerEnabled: true,
-      playerControlsVisibility: "auto",
-    });
-  });
-
-  it("keeps showPlayer compatibility when playerEnabled is not set", () => {
-    expect(resolveSlidePlayerVisibility({ showPlayer: false })).toEqual({
-      playerEnabled: false,
-      playerControlsVisibility: "auto",
+      playerControlsVisibility: "visible",
     });
   });
 });

--- a/src/components/Slide/utils/playerVisibility.test.ts
+++ b/src/components/Slide/utils/playerVisibility.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveSlidePlayerVisibility } from "./playerVisibility";
+
+describe("resolveSlidePlayerVisibility", () => {
+  it("defaults to an enabled player with auto-hidden controls", () => {
+    expect(resolveSlidePlayerVisibility({})).toEqual({
+      playerEnabled: true,
+      playerControlsVisibility: "auto",
+    });
+  });
+
+  it("allows disabling the player runtime", () => {
+    expect(resolveSlidePlayerVisibility({ playerEnabled: false })).toEqual({
+      playerEnabled: false,
+      playerControlsVisibility: "auto",
+    });
+  });
+
+  it("keeps the player enabled when controls are hidden", () => {
+    expect(
+      resolveSlidePlayerVisibility({ playerControlsVisibility: "hidden" })
+    ).toEqual({
+      playerEnabled: true,
+      playerControlsVisibility: "hidden",
+    });
+  });
+
+  it("prefers playerControlsVisibility over playerAlwaysVisible", () => {
+    expect(
+      resolveSlidePlayerVisibility({
+        playerAlwaysVisible: true,
+        playerControlsVisibility: "hidden",
+      })
+    ).toEqual({
+      playerEnabled: true,
+      playerControlsVisibility: "hidden",
+    });
+  });
+
+  it("prefers playerEnabled over showPlayer", () => {
+    expect(
+      resolveSlidePlayerVisibility({
+        playerEnabled: true,
+        showPlayer: false,
+      })
+    ).toEqual({
+      playerEnabled: true,
+      playerControlsVisibility: "auto",
+    });
+  });
+
+  it("keeps showPlayer compatibility when playerEnabled is not set", () => {
+    expect(resolveSlidePlayerVisibility({ showPlayer: false })).toEqual({
+      playerEnabled: false,
+      playerControlsVisibility: "auto",
+    });
+  });
+});

--- a/src/components/Slide/utils/playerVisibility.ts
+++ b/src/components/Slide/utils/playerVisibility.ts
@@ -1,0 +1,24 @@
+export type SlidePlayerControlsVisibility = "auto" | "visible" | "hidden";
+
+export interface ResolveSlidePlayerVisibilityOptions {
+  playerEnabled?: boolean;
+  showPlayer?: boolean;
+  playerControlsVisibility?: SlidePlayerControlsVisibility;
+  playerAlwaysVisible?: boolean;
+}
+
+export interface ResolvedSlidePlayerVisibility {
+  playerEnabled: boolean;
+  playerControlsVisibility: SlidePlayerControlsVisibility;
+}
+
+export const resolveSlidePlayerVisibility = ({
+  playerEnabled,
+  showPlayer,
+  playerControlsVisibility,
+  playerAlwaysVisible,
+}: ResolveSlidePlayerVisibilityOptions): ResolvedSlidePlayerVisibility => ({
+  playerEnabled: playerEnabled ?? showPlayer ?? true,
+  playerControlsVisibility:
+    playerControlsVisibility ?? (playerAlwaysVisible ? "visible" : "auto"),
+});

--- a/src/components/Slide/utils/playerVisibility.ts
+++ b/src/components/Slide/utils/playerVisibility.ts
@@ -2,9 +2,7 @@ export type SlidePlayerControlsVisibility = "auto" | "visible" | "hidden";
 
 export interface ResolveSlidePlayerVisibilityOptions {
   playerEnabled?: boolean;
-  showPlayer?: boolean;
   playerControlsVisibility?: SlidePlayerControlsVisibility;
-  playerAlwaysVisible?: boolean;
 }
 
 export interface ResolvedSlidePlayerVisibility {
@@ -14,11 +12,8 @@ export interface ResolvedSlidePlayerVisibility {
 
 export const resolveSlidePlayerVisibility = ({
   playerEnabled,
-  showPlayer,
   playerControlsVisibility,
-  playerAlwaysVisible,
 }: ResolveSlidePlayerVisibilityOptions): ResolvedSlidePlayerVisibility => ({
-  playerEnabled: playerEnabled ?? showPlayer ?? true,
-  playerControlsVisibility:
-    playerControlsVisibility ?? (playerAlwaysVisible ? "visible" : "auto"),
+  playerEnabled: playerEnabled ?? true,
+  playerControlsVisibility: playerControlsVisibility ?? "auto",
 });

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -22,6 +22,7 @@ export type {
   Element,
   ElementSubtitleCue,
   SlideInteractionTexts,
+  SlidePlayerControlsVisibility,
   SlideProps,
 } from "./Slide";
 export type {


### PR DESCRIPTION
## Summary

- Add `playerEnabled` to control whether the Slide player runtime mounts at all.
- Add `playerControlsVisibility` to choose auto-hidden, always visible, or always hidden controls.
- Remove the legacy `showPlayer` and `playerAlwaysVisible` compatibility props so the public API only exposes explicit runtime and controls-visibility controls.
- Add Storybook examples and unit coverage for the new prop-resolution behavior.

## Validation

- `npm run format`
- `npm run lint`
- `npm test`
- `pnpm exec vitest --project unit src/components/Slide/utils/playerVisibility.test.ts src/components/Slide/utils/playerKeyboardShortcuts.test.ts`
- `pnpm exec next lint --max-warnings 20 --file src/components/Slide/Slide.tsx --file src/components/Slide/Slide.stories.tsx --file src/components/Slide/utils/playerVisibility.ts --file src/components/Slide/utils/playerVisibility.test.ts`
- `pnpm exec next lint --max-warnings 20 --file src/components/Slide/Slide.tsx --file src/components/Slide/Player.tsx --file src/components/Slide/Slide.stories.tsx`
- `pnpm exec prettier --check src/components/Slide/Slide.tsx src/components/Slide/Player.tsx src/components/Slide/Slide.stories.tsx src/components/Slide/utils/playerVisibility.ts src/components/Slide/utils/playerVisibility.test.ts src/components/Slide/index.ts src/components/index.ts`
- `pnpm run build`

Note: `pnpm run build` exited successfully, while the declaration generation step still printed existing unrelated diagnostics in `ContentRender`, old `Slide.stories` fixtures, and `textarea` ref typing.
