### PR TITLE
chore: release markdown-flow-ui 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-flow-ui",
-  "version": "0.1.129",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-flow-ui",
-      "version": "0.1.129",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
       ]
     }
   },
-  "version": "0.1.129",
+  "version": "0.2.0",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
Changed:
Published markdown-flow-ui@0.2.0 via the manual Publish workflow and backfilled the package version files.

Benefit:
Main carries the clean release version that matches the npm latest dist-tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app/package version to `0.2.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->