### PR TITLE
fix: align slide locale defaults with ai-shifu

### DIFF
--- a/src/components/Slide/slideI18n.test.ts
+++ b/src/components/Slide/slideI18n.test.ts
@@ -50,4 +50,14 @@ describe("getSlideLocaleTexts", () => {
       },
     });
   });
+
+  it("normalizes aliases and falls back to en-US for empty or unsupported locales", () => {
+    const englishTexts = getSlideLocaleTexts("en-US");
+    expect(getSlideLocaleTexts(null)).toEqual(englishTexts);
+    expect(getSlideLocaleTexts(undefined)).toEqual(englishTexts);
+    expect(getSlideLocaleTexts("es-ES")).toEqual(englishTexts);
+
+    expect(getSlideLocaleTexts("fr")).toEqual(getSlideLocaleTexts("fr-FR"));
+    expect(getSlideLocaleTexts("zh_CN")).toEqual(getSlideLocaleTexts("zh-CN"));
+  });
 });

--- a/src/components/Slide/slideI18n.test.ts
+++ b/src/components/Slide/slideI18n.test.ts
@@ -22,8 +22,8 @@ describe("getSlideLocaleTexts", () => {
     expect(getSlideLocaleTexts("fr-FR")).toMatchObject({
       bufferingText: {
         waitingForAudio: "En attente de l'audio de la diapositive actuelle...",
-        loadingAudio: "Chargement audio…",
-        waitingForMoreAudio: "En attente de plus d’audio…",
+        loadingAudio: "Chargement audio...",
+        waitingForMoreAudio: "En attente de plus d'audio...",
       },
       fullscreenBackAriaLabel: "Retour au mode non plein écran",
       interactionTexts: {

--- a/src/components/Slide/slideI18n.test.ts
+++ b/src/components/Slide/slideI18n.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { getSlideLocaleTexts } from "./slideI18n";
+
+describe("getSlideLocaleTexts", () => {
+  it("uses selected ai-shifu slide text defaults while preserving interaction and waiting-for-audio copy", () => {
+    expect(getSlideLocaleTexts("en-US")).toMatchObject({
+      bufferingText: {
+        waitingForAudio: "Waiting for current slide audio...",
+        loadingAudio: "Loading audio...",
+        waitingForMoreAudio: "Waiting for more audio...",
+      },
+      fullscreenBackAriaLabel: "Back to non-full screen",
+      interactionTexts: {
+        title: "Submit the content below to continue.",
+      },
+      playerTexts: {
+        fullscreenHintText: "Please rotate your screen for the best experience",
+      },
+    });
+
+    expect(getSlideLocaleTexts("fr-FR")).toMatchObject({
+      bufferingText: {
+        waitingForAudio: "En attente de l'audio de la diapositive actuelle...",
+        loadingAudio: "Chargement audio…",
+        waitingForMoreAudio: "En attente de plus d’audio…",
+      },
+      fullscreenBackAriaLabel: "Retour au mode non plein écran",
+      interactionTexts: {
+        title: "Soumettez le contenu ci-dessous pour continuer.",
+      },
+      playerTexts: {
+        fullscreenHintText:
+          "Veuillez tourner votre écran pour une meilleure expérience",
+      },
+    });
+
+    expect(getSlideLocaleTexts("zh-CN")).toMatchObject({
+      bufferingText: {
+        waitingForAudio: "正在等待当前页音频...",
+        loadingAudio: "正在加载音频",
+        waitingForMoreAudio: "正在等待音频",
+      },
+      fullscreenBackAriaLabel: "返回非全屏",
+      interactionTexts: {
+        title: "提交下面的内容以继续",
+      },
+      playerTexts: {
+        fullscreenHintText: "请旋转屏幕以获得最佳体验",
+      },
+    });
+  });
+});

--- a/src/components/Slide/slideI18n.ts
+++ b/src/components/Slide/slideI18n.ts
@@ -173,8 +173,8 @@ export const SLIDE_LOCALE_TEXTS: Record<MarkdownFlowLocale, SlideLocaleTexts> =
       "Retour au mode non plein écran",
       [
         "En attente de l'audio de la diapositive actuelle...",
-        "Chargement audio…",
-        "En attente de plus d’audio…",
+        "Chargement audio...",
+        "En attente de plus d'audio...",
       ],
       [
         "Soumettez le contenu ci-dessous pour continuer.",

--- a/src/components/Slide/slideI18n.ts
+++ b/src/components/Slide/slideI18n.ts
@@ -144,7 +144,7 @@ export const DEFAULT_SLIDE_PLAYER_TEXTS: SlidePlayerLocaleTexts =
     "Screen",
     "Non-fullscreen",
     "Fullscreen",
-    "Rotate your screen for the best experience.",
+    "Please rotate your screen for the best experience",
   ]);
 
 export const DEFAULT_SLIDE_INTERACTION_TEXTS: SlideInteractionLocaleTexts =
@@ -157,24 +157,24 @@ export const DEFAULT_SLIDE_INTERACTION_TEXTS: SlideInteractionLocaleTexts =
 
 export const DEFAULT_SLIDE_BUFFERING_TEXTS = createSlideBufferingTexts([
   "Waiting for current slide audio...",
-  "Loading current slide audio...",
-  "Waiting for more current slide audio...",
+  "Loading audio...",
+  "Waiting for more audio...",
 ]);
 
 export const SLIDE_LOCALE_TEXTS: Record<MarkdownFlowLocale, SlideLocaleTexts> =
   {
     "en-US": {
       bufferingText: DEFAULT_SLIDE_BUFFERING_TEXTS,
-      fullscreenBackAriaLabel: "Back",
+      fullscreenBackAriaLabel: "Back to non-full screen",
       interactionTexts: DEFAULT_SLIDE_INTERACTION_TEXTS,
       playerTexts: DEFAULT_SLIDE_PLAYER_TEXTS,
     },
     "fr-FR": createSlideLocaleTexts(
-      "Retour",
+      "Retour au mode non plein écran",
       [
         "En attente de l'audio de la diapositive actuelle...",
-        "Chargement de l'audio de la diapositive actuelle...",
-        "En attente de la suite de l'audio de la diapositive actuelle...",
+        "Chargement audio…",
+        "En attente de plus d’audio…",
       ],
       [
         "Soumettez le contenu ci-dessous pour continuer.",
@@ -204,16 +204,12 @@ export const SLIDE_LOCALE_TEXTS: Record<MarkdownFlowLocale, SlideLocaleTexts> =
         "Écran",
         "Hors plein écran",
         "Plein écran",
-        "Faites pivoter votre écran pour une meilleure expérience.",
+        "Veuillez tourner votre écran pour une meilleure expérience",
       ]
     ),
     "zh-CN": createSlideLocaleTexts(
-      "返回",
-      [
-        "正在等待当前页音频...",
-        "正在加载当前页音频...",
-        "正在等待更多当前页音频...",
-      ],
+      "返回非全屏",
+      ["正在等待当前页音频...", "正在加载音频", "正在等待音频"],
       ["提交下面的内容以继续", "提交", "复制", "已复制"],
       [
         "关闭设置",
@@ -237,7 +233,7 @@ export const SLIDE_LOCALE_TEXTS: Record<MarkdownFlowLocale, SlideLocaleTexts> =
         "屏幕",
         "非全屏",
         "全屏",
-        "旋转屏幕以获得更好的体验。",
+        "请旋转屏幕以获得最佳体验",
       ]
     ),
   };


### PR DESCRIPTION
## Summary
- Align Slide built-in locale defaults with ai-shifu's remaining overrides for audio loading/waiting-more text, fullscreen hints, and fullscreen back labels.
- Keep interaction title defaults unchanged, so ai-shifu can continue to override module.chat.listenInteractionHint.
- Keep waiting-for-audio defaults unchanged, so ai-shifu can continue to override that one with module.chat.thinking.
- Add focused unit coverage for en-US, fr-FR, zh-CN, and locale fallback/normalization behavior.

## Verification
- pnpm exec vitest run src/components/Slide/slideI18n.test.ts --project unit
- npm run format
- npm run format:check
- npm test
- npm run lint
- npm run typecheck:exports
- npm run build
- git diff --check

Note: npm run build exited 0; Vite dts still printed existing type diagnostics outside the changed locale files.