### PR TITLE
fix: open sandbox-rendered links in a new tab

### DIFF
--- a/src/components/ContentRender/SandboxApp.tsx
+++ b/src/components/ContentRender/SandboxApp.tsx
@@ -4,7 +4,6 @@ import type { MarkdownFlowLocale } from "../../lib/locale";
 import { getContentRenderLocaleTexts } from "./contentRenderI18n";
 import type { ScalingWindow } from "./utils/iframe-scaling";
 import {
-  forceSandboxLinksToOpenInNewTab,
   mergeAnchorRelValue,
   shouldForceAnchorHrefToNewTab,
 } from "./utils/link-targets";
@@ -207,7 +206,19 @@ const SandboxApp: React.FC<SandboxAppProps> = ({
     setIsGeneratingStyles(false);
     setIsGeneratingScripts(false);
     const wrapper = doc.createElement("div");
-    wrapper.innerHTML = forceSandboxLinksToOpenInNewTab(html);
+    wrapper.innerHTML = html;
+    wrapper.querySelectorAll("a[href]").forEach((node) => {
+      if (!(node instanceof HTMLAnchorElement)) {
+        return;
+      }
+
+      if (!shouldForceAnchorHrefToNewTab(node.getAttribute("href"))) {
+        return;
+      }
+
+      node.setAttribute("target", "_blank");
+      node.setAttribute("rel", mergeAnchorRelValue(node.getAttribute("rel")));
+    });
 
     const openScriptCount = (html.match(/<script[\s>]/gi) || []).length;
     const closeScriptCount = (html.match(/<\/script>/gi) || []).length;

--- a/src/components/ContentRender/SandboxApp.tsx
+++ b/src/components/ContentRender/SandboxApp.tsx
@@ -3,6 +3,11 @@ import LoadingOverlayCard from "../ui/loading-overlay-card";
 import type { MarkdownFlowLocale } from "../../lib/locale";
 import { getContentRenderLocaleTexts } from "./contentRenderI18n";
 import type { ScalingWindow } from "./utils/iframe-scaling";
+import {
+  forceSandboxLinksToOpenInNewTab,
+  mergeAnchorRelValue,
+  shouldForceAnchorHrefToNewTab,
+} from "./utils/link-targets";
 
 export interface SandboxAppProps {
   html: string;
@@ -202,7 +207,7 @@ const SandboxApp: React.FC<SandboxAppProps> = ({
     setIsGeneratingStyles(false);
     setIsGeneratingScripts(false);
     const wrapper = doc.createElement("div");
-    wrapper.innerHTML = html;
+    wrapper.innerHTML = forceSandboxLinksToOpenInNewTab(html);
 
     const openScriptCount = (html.match(/<script[\s>]/gi) || []).length;
     const closeScriptCount = (html.match(/<\/script>/gi) || []).length;
@@ -254,6 +259,29 @@ const SandboxApp: React.FC<SandboxAppProps> = ({
     const hasInitialContent = contentNodes.length > 0;
     setHasRenderedContent(hasInitialContent);
     container.replaceChildren(...contentNodes);
+
+    const handleLinkClick = (event: MouseEvent) => {
+      const clickTarget = event.target;
+      if (!(clickTarget instanceof Element)) {
+        return;
+      }
+
+      const anchor = clickTarget.closest("a[href]");
+      if (!(anchor instanceof HTMLAnchorElement)) {
+        return;
+      }
+
+      if (!shouldForceAnchorHrefToNewTab(anchor.getAttribute("href"))) {
+        return;
+      }
+
+      anchor.setAttribute("target", "_blank");
+      anchor.setAttribute(
+        "rel",
+        mergeAnchorRelValue(anchor.getAttribute("rel"))
+      );
+    };
+    container.addEventListener("click", handleLinkClick, true);
 
     let scriptContentObserver: MutationObserver | null = null;
     const markRenderedContentFromContainer = () => {
@@ -341,6 +369,7 @@ const SandboxApp: React.FC<SandboxAppProps> = ({
 
     return () => {
       scriptContentObserver?.disconnect();
+      container.removeEventListener("click", handleLinkClick, true);
     };
   }, [html, resetToken, enableScaling]);
 

--- a/src/components/ContentRender/SandboxApp.tsx
+++ b/src/components/ContentRender/SandboxApp.tsx
@@ -4,7 +4,9 @@ import type { MarkdownFlowLocale } from "../../lib/locale";
 import { getContentRenderLocaleTexts } from "./contentRenderI18n";
 import type { ScalingWindow } from "./utils/iframe-scaling";
 import {
+  isAnchorElement,
   mergeAnchorRelValue,
+  resolveClosestAnchor,
   shouldForceAnchorHrefToNewTab,
 } from "./utils/link-targets";
 
@@ -208,7 +210,7 @@ const SandboxApp: React.FC<SandboxAppProps> = ({
     const wrapper = doc.createElement("div");
     wrapper.innerHTML = html;
     wrapper.querySelectorAll("a[href]").forEach((node) => {
-      if (!(node instanceof HTMLAnchorElement)) {
+      if (!isAnchorElement(node)) {
         return;
       }
 
@@ -272,13 +274,8 @@ const SandboxApp: React.FC<SandboxAppProps> = ({
     container.replaceChildren(...contentNodes);
 
     const handleLinkClick = (event: MouseEvent) => {
-      const clickTarget = event.target;
-      if (!(clickTarget instanceof Element)) {
-        return;
-      }
-
-      const anchor = clickTarget.closest("a[href]");
-      if (!(anchor instanceof HTMLAnchorElement)) {
+      const anchor = resolveClosestAnchor(event.target);
+      if (!anchor) {
         return;
       }
 

--- a/src/components/ContentRender/utils/link-targets.test.ts
+++ b/src/components/ContentRender/utils/link-targets.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  forceSandboxLinksToOpenInNewTab,
+  mergeAnchorRelValue,
+  shouldForceAnchorHrefToNewTab,
+} from "./link-targets";
+
+describe("shouldForceAnchorHrefToNewTab", () => {
+  it("returns true for regular links", () => {
+    expect(shouldForceAnchorHrefToNewTab("https://app.ai-shifu.cn")).toBe(true);
+    expect(shouldForceAnchorHrefToNewTab("/docs/lesson")).toBe(true);
+  });
+
+  it("skips hash and javascript links", () => {
+    expect(shouldForceAnchorHrefToNewTab("#section-1")).toBe(false);
+    expect(shouldForceAnchorHrefToNewTab(" javascript:void(0) ")).toBe(false);
+    expect(shouldForceAnchorHrefToNewTab(null)).toBe(false);
+  });
+});
+
+describe("mergeAnchorRelValue", () => {
+  it("adds noopener and noreferrer without duplicating tokens", () => {
+    expect(mergeAnchorRelValue("nofollow noopener")).toBe(
+      "nofollow noopener noreferrer"
+    );
+    expect(mergeAnchorRelValue(null)).toBe("noopener noreferrer");
+  });
+});
+
+describe("forceSandboxLinksToOpenInNewTab", () => {
+  it("adds target and rel to external links", () => {
+    expect(
+      forceSandboxLinksToOpenInNewTab(
+        '<p><a href="https://app.ai-shifu.cn/course/1">Learn course</a></p>'
+      )
+    ).toContain(
+      '<a href="https://app.ai-shifu.cn/course/1" target="_blank" rel="noopener noreferrer">'
+    );
+  });
+
+  it("preserves existing rel tokens while adding safe ones", () => {
+    expect(
+      forceSandboxLinksToOpenInNewTab(
+        '<a href="/c/test" rel="nofollow">Course link</a>'
+      )
+    ).toContain(
+      '<a href="/c/test" rel="nofollow noopener noreferrer" target="_blank">'
+    );
+  });
+
+  it("does not patch hash or javascript links", () => {
+    expect(
+      forceSandboxLinksToOpenInNewTab('<a href="#chapter-1">Jump</a>')
+    ).toBe('<a href="#chapter-1">Jump</a>');
+    expect(
+      forceSandboxLinksToOpenInNewTab(
+        '<a href="javascript:void(0)">Open menu</a>'
+      )
+    ).toBe('<a href="javascript:void(0)">Open menu</a>');
+  });
+});

--- a/src/components/ContentRender/utils/link-targets.test.ts
+++ b/src/components/ContentRender/utils/link-targets.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
+  isAnchorElement,
   mergeAnchorRelValue,
+  resolveClosestAnchor,
   shouldForceAnchorHrefToNewTab,
 } from "./link-targets";
 
@@ -36,6 +38,35 @@ describe("mergeAnchorRelValue", () => {
     expect(mergeAnchorRelValue("noopener noreferrer nofollow noreferrer")).toBe(
       "noopener noreferrer nofollow"
     );
+  });
+});
+
+describe("realm-safe anchor helpers", () => {
+  it("identifies anchor elements by tagName instead of instanceof", () => {
+    expect(isAnchorElement({ tagName: "A" })).toBe(true);
+    expect(isAnchorElement({ tagName: "DIV" })).toBe(false);
+  });
+
+  it("resolves anchors via closest from element-like event targets", () => {
+    const anchor = { tagName: "A" } as HTMLAnchorElement;
+    const closest = vi.fn(() => anchor);
+
+    expect(resolveClosestAnchor({ closest } as unknown as EventTarget)).toBe(
+      anchor
+    );
+    expect(closest).toHaveBeenCalledWith("a[href]");
+  });
+
+  it("falls back to parentElement.closest for text-node-like targets", () => {
+    const anchor = { tagName: "A" } as HTMLAnchorElement;
+    const closest = vi.fn(() => anchor);
+
+    expect(
+      resolveClosestAnchor({
+        parentElement: { closest },
+      } as unknown as EventTarget)
+    ).toBe(anchor);
+    expect(closest).toHaveBeenCalledWith("a[href]");
   });
 });
 

--- a/src/components/ContentRender/utils/link-targets.test.ts
+++ b/src/components/ContentRender/utils/link-targets.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  forceSandboxLinksToOpenInNewTab,
   mergeAnchorRelValue,
   shouldForceAnchorHrefToNewTab,
 } from "./link-targets";
@@ -12,9 +11,15 @@ describe("shouldForceAnchorHrefToNewTab", () => {
     expect(shouldForceAnchorHrefToNewTab("/docs/lesson")).toBe(true);
   });
 
-  it("skips hash and javascript links", () => {
+  it("skips non-navigating and external-app links", () => {
+    expect(shouldForceAnchorHrefToNewTab("")).toBe(false);
     expect(shouldForceAnchorHrefToNewTab("#section-1")).toBe(false);
     expect(shouldForceAnchorHrefToNewTab(" javascript:void(0) ")).toBe(false);
+    expect(shouldForceAnchorHrefToNewTab("data:text/plain,hello")).toBe(false);
+    expect(shouldForceAnchorHrefToNewTab("mailto:hello@example.com")).toBe(
+      false
+    );
+    expect(shouldForceAnchorHrefToNewTab("tel:+8613800138000")).toBe(false);
     expect(shouldForceAnchorHrefToNewTab(null)).toBe(false);
   });
 });
@@ -26,37 +31,29 @@ describe("mergeAnchorRelValue", () => {
     );
     expect(mergeAnchorRelValue(null)).toBe("noopener noreferrer");
   });
+
+  it("keeps rel tokens unique", () => {
+    expect(mergeAnchorRelValue("noopener noreferrer nofollow noreferrer")).toBe(
+      "noopener noreferrer nofollow"
+    );
+  });
 });
 
-describe("forceSandboxLinksToOpenInNewTab", () => {
-  it("adds target and rel to external links", () => {
+describe("href edge cases", () => {
+  it("treats query strings containing target or rel as normal URLs", () => {
     expect(
-      forceSandboxLinksToOpenInNewTab(
-        '<p><a href="https://app.ai-shifu.cn/course/1">Learn course</a></p>'
+      shouldForceAnchorHrefToNewTab(
+        "https://app.ai-shifu.cn/course/2?target=keep&rel=safe"
       )
-    ).toContain(
-      '<a href="https://app.ai-shifu.cn/course/1" target="_blank" rel="noopener noreferrer">'
-    );
+    ).toBe(true);
   });
 
-  it("preserves existing rel tokens while adding safe ones", () => {
+  it("treats values from single-quoted and unquoted href attributes as normal URLs", () => {
     expect(
-      forceSandboxLinksToOpenInNewTab(
-        '<a href="/c/test" rel="nofollow">Course link</a>'
-      )
-    ).toContain(
-      '<a href="/c/test" rel="nofollow noopener noreferrer" target="_blank">'
-    );
-  });
-
-  it("does not patch hash or javascript links", () => {
+      shouldForceAnchorHrefToNewTab("https://app.ai-shifu.cn/course/1")
+    ).toBe(true);
     expect(
-      forceSandboxLinksToOpenInNewTab('<a href="#chapter-1">Jump</a>')
-    ).toBe('<a href="#chapter-1">Jump</a>');
-    expect(
-      forceSandboxLinksToOpenInNewTab(
-        '<a href="javascript:void(0)">Open menu</a>'
-      )
-    ).toBe('<a href="javascript:void(0)">Open menu</a>');
+      shouldForceAnchorHrefToNewTab("https://app.ai-shifu.cn/course/2")
+    ).toBe(true);
   });
 });

--- a/src/components/ContentRender/utils/link-targets.ts
+++ b/src/components/ContentRender/utils/link-targets.ts
@@ -1,40 +1,3 @@
-const ANCHOR_WITH_HREF_PATTERN =
-  /<a\b([^>]*\bhref\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)[^>]*)>/gi;
-
-const readAttributeValue = (attributes: string, attributeName: string) => {
-  const pattern = new RegExp(
-    `\\b${attributeName}\\s*=\\s*(\"([^\"]*)\"|'([^']*)'|([^\\s>]+))`,
-    "i"
-  );
-  const match = attributes.match(pattern);
-
-  if (!match) {
-    return null;
-  }
-
-  return match[2] ?? match[3] ?? match[4] ?? "";
-};
-
-const writeAttributeValue = (
-  attributes: string,
-  attributeName: string,
-  attributeValue: string
-) => {
-  const pattern = new RegExp(
-    `(\\b${attributeName}\\s*=\\s*)(\"[^\"]*\"|'[^']*'|[^\\s>]+)`,
-    "i"
-  );
-
-  if (pattern.test(attributes)) {
-    return attributes.replace(
-      pattern,
-      `$1"${attributeValue.replace(/"/g, "&quot;")}"`
-    );
-  }
-
-  return `${attributes} ${attributeName}="${attributeValue.replace(/"/g, "&quot;")}"`;
-};
-
 export const shouldForceAnchorHrefToNewTab = (href: string | null) => {
   const normalizedHref = href?.trim().toLowerCase() ?? "";
 
@@ -44,7 +7,10 @@ export const shouldForceAnchorHrefToNewTab = (href: string | null) => {
 
   if (
     normalizedHref.startsWith("#") ||
-    normalizedHref.startsWith("javascript:")
+    normalizedHref.startsWith("javascript:") ||
+    normalizedHref.startsWith("data:") ||
+    normalizedHref.startsWith("mailto:") ||
+    normalizedHref.startsWith("tel:")
   ) {
     return false;
   }
@@ -65,21 +31,3 @@ export const mergeAnchorRelValue = (rel: string | null) => {
 
   return Array.from(tokens).join(" ");
 };
-
-const patchAnchorTagAttributes = (attributes: string) => {
-  const href = readAttributeValue(attributes, "href");
-  if (!shouldForceAnchorHrefToNewTab(href)) {
-    return attributes;
-  }
-
-  const nextRel = mergeAnchorRelValue(readAttributeValue(attributes, "rel"));
-  const withTarget = writeAttributeValue(attributes, "target", "_blank");
-
-  return writeAttributeValue(withTarget, "rel", nextRel);
-};
-
-export const forceSandboxLinksToOpenInNewTab = (html: string) =>
-  html.replace(ANCHOR_WITH_HREF_PATTERN, (fullMatch, attributes: string) => {
-    const nextAttributes = patchAnchorTagAttributes(attributes);
-    return `<a${nextAttributes}>`;
-  });

--- a/src/components/ContentRender/utils/link-targets.ts
+++ b/src/components/ContentRender/utils/link-targets.ts
@@ -1,0 +1,85 @@
+const ANCHOR_WITH_HREF_PATTERN =
+  /<a\b([^>]*\bhref\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)[^>]*)>/gi;
+
+const readAttributeValue = (attributes: string, attributeName: string) => {
+  const pattern = new RegExp(
+    `\\b${attributeName}\\s*=\\s*(\"([^\"]*)\"|'([^']*)'|([^\\s>]+))`,
+    "i"
+  );
+  const match = attributes.match(pattern);
+
+  if (!match) {
+    return null;
+  }
+
+  return match[2] ?? match[3] ?? match[4] ?? "";
+};
+
+const writeAttributeValue = (
+  attributes: string,
+  attributeName: string,
+  attributeValue: string
+) => {
+  const pattern = new RegExp(
+    `(\\b${attributeName}\\s*=\\s*)(\"[^\"]*\"|'[^']*'|[^\\s>]+)`,
+    "i"
+  );
+
+  if (pattern.test(attributes)) {
+    return attributes.replace(
+      pattern,
+      `$1"${attributeValue.replace(/"/g, "&quot;")}"`
+    );
+  }
+
+  return `${attributes} ${attributeName}="${attributeValue.replace(/"/g, "&quot;")}"`;
+};
+
+export const shouldForceAnchorHrefToNewTab = (href: string | null) => {
+  const normalizedHref = href?.trim().toLowerCase() ?? "";
+
+  if (!normalizedHref) {
+    return false;
+  }
+
+  if (
+    normalizedHref.startsWith("#") ||
+    normalizedHref.startsWith("javascript:")
+  ) {
+    return false;
+  }
+
+  return true;
+};
+
+export const mergeAnchorRelValue = (rel: string | null) => {
+  const tokens = new Set(
+    (rel ?? "")
+      .split(/\s+/)
+      .map((token) => token.trim())
+      .filter(Boolean)
+  );
+
+  tokens.add("noopener");
+  tokens.add("noreferrer");
+
+  return Array.from(tokens).join(" ");
+};
+
+const patchAnchorTagAttributes = (attributes: string) => {
+  const href = readAttributeValue(attributes, "href");
+  if (!shouldForceAnchorHrefToNewTab(href)) {
+    return attributes;
+  }
+
+  const nextRel = mergeAnchorRelValue(readAttributeValue(attributes, "rel"));
+  const withTarget = writeAttributeValue(attributes, "target", "_blank");
+
+  return writeAttributeValue(withTarget, "rel", nextRel);
+};
+
+export const forceSandboxLinksToOpenInNewTab = (html: string) =>
+  html.replace(ANCHOR_WITH_HREF_PATTERN, (fullMatch, attributes: string) => {
+    const nextAttributes = patchAnchorTagAttributes(attributes);
+    return `<a${nextAttributes}>`;
+  });

--- a/src/components/ContentRender/utils/link-targets.ts
+++ b/src/components/ContentRender/utils/link-targets.ts
@@ -18,6 +18,29 @@ export const shouldForceAnchorHrefToNewTab = (href: string | null) => {
   return true;
 };
 
+export const isAnchorElement = (
+  node: { tagName?: string | null } | null | undefined
+): node is HTMLAnchorElement => node?.tagName?.toLowerCase() === "a";
+
+export const resolveClosestAnchor = (target: EventTarget | null) => {
+  const candidate = target as {
+    closest?: (selector: string) => Element | null;
+    parentElement?: Element | null;
+  } | null;
+
+  if (!candidate) {
+    return null;
+  }
+
+  if (typeof candidate.closest === "function") {
+    const anchor = candidate.closest("a[href]");
+    return isAnchorElement(anchor) ? anchor : null;
+  }
+
+  const anchor = candidate.parentElement?.closest("a[href]");
+  return isAnchorElement(anchor) ? anchor : null;
+};
+
 export const mergeAnchorRelValue = (rel: string | null) => {
   const tokens = new Set(
     (rel ?? "")


### PR DESCRIPTION
Summary
- patch sandbox-rendered anchor tags to open external links in a new tab
- replace cross-realm `instanceof` anchor checks with iframe-safe `tagName` / `closest("a[href]")` helpers so sandbox document nodes are recognized correctly
- add safe rel attributes, keep the click-time fallback for dynamic anchors, and cover the realm-safe helpers with focused tests

Testing
- `cd /Users/iris/markdown-flow-ui && npx vitest run src/components/ContentRender/utils/link-targets.test.ts`
- `cd /Users/iris/markdown-flow-ui && npm run lint`
- `cd /Users/iris/markdown-flow-ui && npm run build`

Notes
- this addresses the iframe cross-realm review concern directly; without the helper change, sandbox DOM nodes can fail `instanceof HTMLAnchorElement` checks even when they are real anchors
- the repository build still prints pre-existing TypeScript diagnostics during declaration generation, but the full build completes successfully and they are unrelated to this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Links in sandbox-rendered content that point to eligible external or root-relative destinations now open in a new browser tab.
  * Link security attributes are automatically updated to include the appropriate protection tokens, while preserving existing values.

* **Bug Fixes**
  * Hash links and unsafe schemes (for example, `javascript:`) are no longer redirected to new tabs.
  * Added more robust handling for links clicked within dynamically updated sandbox content.

* **Tests**
  * Expanded coverage for link-target and `rel` handling edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
