### PR TITLE
fix: add CJK font fallbacks

### DIFF
--- a/src/components/ContentRender/ContentRender.stories.tsx
+++ b/src/components/ContentRender/ContentRender.stories.tsx
@@ -2437,6 +2437,41 @@ export const HTMLDemoIframeOnly: Story = {
   },
 };
 
+export const SandboxCJKFontFallback: Story = {
+  args: {},
+  parameters: {
+    layout: "fullscreen",
+  },
+  render: () => (
+    <div style={{ width: "100%", padding: "24px" }}>
+      <div style={{ height: "320px" }}>
+        <IframeSandbox
+          hideFullScreen
+          type="sandbox"
+          mode="blackboard"
+          content={`
+            <div class="h-full bg-slate-50 p-8 text-slate-900">
+              <h1 data-cjk-font-case="inherited" class="text-3xl font-bold">中文默认字体回退</h1>
+              <p data-cjk-font-case="font-sans" class="mt-4 font-sans text-xl">Tailwind font-sans 中文内容</p>
+              <svg class="mt-6" width="420" height="80" viewBox="0 0 420 80" role="img" aria-label="CJK font fallback diagram">
+                <text data-cjk-font-case="svg" x="8" y="48" font-size="28">图表中的中文标签</text>
+              </svg>
+            </div>
+          `}
+        />
+      </div>
+      <div data-cjk-font-case="mermaid" style={{ marginTop: "24px" }}>
+        <ContentRender
+          content={`\`\`\`mermaid
+flowchart LR
+  A[中文图表] --> B[PDF 标签]
+\`\`\``}
+        />
+      </div>
+    </div>
+  ),
+};
+
 export const ReadingModeAppendedAskBlocks: Story = {
   name: "Reading Mode Appended Ask Blocks",
   args: {},

--- a/src/components/ContentRender/IframeSandbox.tsx
+++ b/src/components/ContentRender/IframeSandbox.tsx
@@ -25,6 +25,7 @@ import {
 } from "./utils/iframe-scaling";
 import type { MarkdownFlowLocale } from "../../lib/locale";
 import { getContentRenderLocaleTexts } from "./contentRenderI18n";
+import { CJK_SAFE_SANS_FONT_FAMILY } from "./cjkFontFamily";
 
 type InjectBlackboardLibraries =
   typeof import("./blackboard-vendor").injectBlackboardLibraries;
@@ -311,7 +312,7 @@ const IframeSandbox: React.FC<IframeSandboxProps> = ({
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <style>
       :root { color-scheme: light; }
-      html, body, #root { width: 100%; }
+      html, body, #root { width: 100%; font-family: ${CJK_SAFE_SANS_FONT_FAMILY}; }
       ${mode === "blackboard" ? "html, body, #root { height: 100%; }" : ""}
       html, body { margin: 0; padding: 0; overflow: ${shouldEnableScaling ? "hidden auto" : mode === "blackboard" ? "auto" : "hidden"}; }
       *, *::before, *::after { box-sizing: border-box; }

--- a/src/components/ContentRender/blackboard-vendor.ts
+++ b/src/components/ContentRender/blackboard-vendor.ts
@@ -17,6 +17,8 @@ export function injectBlackboardLibraries(doc: Document): void {
   // 1. Tailwind CSS v3 (JIT compiler, must load first)
   const tailwindEl = doc.createElement("script");
   tailwindEl.textContent = tailwindScript;
+  // The Play CDN script replaces window.tailwind with its Proxy during execution,
+  // so configure that runtime only after the synchronous append completes.
   doc.head.appendChild(tailwindEl);
   const tailwindRuntime = (doc.defaultView as TailwindRuntimeWindow | null)
     ?.tailwind;

--- a/src/components/ContentRender/blackboard-vendor.ts
+++ b/src/components/ContentRender/blackboard-vendor.ts
@@ -1,6 +1,13 @@
 import tailwindScript from "./vendor/tailwindcss-v3.min.js?raw";
 import daisyuiCss from "./vendor/daisyui-v4.min.css?raw";
 import gsapScript from "./vendor/gsap-v3.min.js?raw";
+import { addCjkSafeSansToTailwindConfig } from "./cjkFontFamily";
+
+interface TailwindRuntimeWindow extends Window {
+  tailwind?: {
+    config?: unknown;
+  };
+}
 
 /**
  * Inject blackboard-mode libraries (Tailwind CSS, DaisyUI, GSAP)
@@ -11,6 +18,13 @@ export function injectBlackboardLibraries(doc: Document): void {
   const tailwindEl = doc.createElement("script");
   tailwindEl.textContent = tailwindScript;
   doc.head.appendChild(tailwindEl);
+  const tailwindRuntime = (doc.defaultView as TailwindRuntimeWindow | null)
+    ?.tailwind;
+  if (tailwindRuntime) {
+    tailwindRuntime.config = addCjkSafeSansToTailwindConfig(
+      tailwindRuntime.config
+    );
+  }
 
   // 2. DaisyUI v4 CSS
   const daisyuiEl = doc.createElement("style");

--- a/src/components/ContentRender/cjkFontFamily.test.ts
+++ b/src/components/ContentRender/cjkFontFamily.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  addCjkSafeSansToTailwindConfig,
+  CJK_SAFE_SANS_FONT_FAMILIES,
+  CJK_SAFE_SANS_FONT_FAMILY,
+} from "./cjkFontFamily";
+
+describe("CJK-safe sans font family", () => {
+  it("keeps system fonts first and adds cross-platform CJK fallbacks", () => {
+    expect(CJK_SAFE_SANS_FONT_FAMILIES[0]).toBe("system-ui");
+    expect(CJK_SAFE_SANS_FONT_FAMILY).toContain('"PingFang SC"');
+    expect(CJK_SAFE_SANS_FONT_FAMILY).toContain('"Microsoft YaHei"');
+    expect(CJK_SAFE_SANS_FONT_FAMILY).toContain('"Noto Sans CJK SC"');
+    expect(CJK_SAFE_SANS_FONT_FAMILIES.at(-1)).toBe("sans-serif");
+  });
+
+  it("extends Tailwind sans fonts without dropping existing configuration", () => {
+    const result = addCjkSafeSansToTailwindConfig({
+      darkMode: "class",
+      theme: {
+        extend: {
+          colors: { brand: "#0f63ee" },
+          fontFamily: { mono: ["monospace"] },
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      darkMode: "class",
+      theme: {
+        extend: {
+          colors: { brand: "#0f63ee" },
+          fontFamily: {
+            mono: ["monospace"],
+            sans: [...CJK_SAFE_SANS_FONT_FAMILIES],
+          },
+        },
+      },
+    });
+  });
+});

--- a/src/components/ContentRender/cjkFontFamily.ts
+++ b/src/components/ContentRender/cjkFontFamily.ts
@@ -1,0 +1,56 @@
+export const CJK_SAFE_SANS_FONT_FAMILIES = [
+  "system-ui",
+  "-apple-system",
+  "BlinkMacSystemFont",
+  '"Segoe UI"',
+  "Roboto",
+  "Oxygen",
+  "Ubuntu",
+  "Cantarell",
+  '"Open Sans"',
+  '"Helvetica Neue"',
+  '"PingFang SC"',
+  '"Hiragino Sans GB"',
+  '"Microsoft YaHei"',
+  '"Source Han Sans SC"',
+  '"Noto Sans CJK SC"',
+  '"Noto Sans SC"',
+  "Arial",
+  '"Apple Color Emoji"',
+  '"Segoe UI Emoji"',
+  '"Segoe UI Symbol"',
+  '"Noto Color Emoji"',
+  "sans-serif",
+] as const;
+
+export const CJK_SAFE_SANS_FONT_FAMILY = CJK_SAFE_SANS_FONT_FAMILIES.join(", ");
+
+type UnknownRecord = Record<string, unknown>;
+
+const asRecord = (value: unknown): UnknownRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : {};
+
+export const addCjkSafeSansToTailwindConfig = (
+  config: unknown
+): UnknownRecord => {
+  const rootConfig = asRecord(config);
+  const theme = asRecord(rootConfig.theme);
+  const extend = asRecord(theme.extend);
+  const fontFamily = asRecord(extend.fontFamily);
+
+  return {
+    ...rootConfig,
+    theme: {
+      ...theme,
+      extend: {
+        ...extend,
+        fontFamily: {
+          ...fontFamily,
+          sans: [...CJK_SAFE_SANS_FONT_FAMILIES],
+        },
+      },
+    },
+  };
+};

--- a/src/components/ContentRender/plugins/MermaidChart.tsx
+++ b/src/components/ContentRender/plugins/MermaidChart.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import mermaid from "mermaid";
+import { CJK_SAFE_SANS_FONT_FAMILY } from "../cjkFontFamily";
 
 export interface MermaidChartProps {
   chart: string;
@@ -16,9 +17,6 @@ const DEFAULT_MESSAGES = {
   loading: "Loading Mermaid chart...",
   badge: "mermaid",
 } as const;
-
-const MERMAID_FONT_STACK =
-  '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif';
 
 const preprocessChart = (raw: string) =>
   raw.trim().replace(/^_streaming\s*/i, "");
@@ -42,16 +40,16 @@ const MermaidChart: React.FC<MermaidChartProps> = ({
         return;
       }
 
-      // Initialize mermaid with the same font stack used in markdown content.
+      // Initialize Mermaid with an explicit CJK-safe font stack.
       // Using a concrete stack avoids clipping caused by `inherit` resolving to
       // Storybook's default font during off-screen rendering.
       mermaid.initialize({
         startOnLoad: false,
         theme: "default",
         securityLevel: "loose",
-        fontFamily: MERMAID_FONT_STACK,
+        fontFamily: CJK_SAFE_SANS_FONT_FAMILY,
         themeVariables: {
-          fontFamily: MERMAID_FONT_STACK,
+          fontFamily: CJK_SAFE_SANS_FONT_FAMILY,
         },
       });
 


### PR DESCRIPTION
## Summary

- Add a shared cross-platform CJK-safe sans-serif fallback stack.
- Apply it to iframe content, Tailwind runtime configuration, and Mermaid SVG labels.
- Add regression coverage and a Storybook example for Chinese fallback rendering.

## Why

Browser PDF generation can omit Chinese glyphs when isolated rendering contexts rely on implicit font fallback. The explicit stack lets Chromium resolve and embed an installed CJK font.

## Validation

- `pnpm exec vitest run src/components/ContentRender/cjkFontFamily.test.ts`
- `npm run lint`
- `npm run format:check`
- `pnpm run typecheck:exports`
- `npm run build`
- `npm run build-storybook`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Chinese, Japanese, and Korean text rendering across Mermaid charts and sandboxed content.
  * Added consistent CJK font fallbacks for embedded previews and Tailwind-styled content.
  * Preserved existing styling and configuration while applying the improved font fallback behavior.

* **Tests**
  * Added coverage validating CJK font fallback configuration and rendering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->