### PR TITLE
chore: release markdown-flow-ui 0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-flow-ui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-flow-ui",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
       ]
     }
   },
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Release

Publish markdown-flow-ui@0.2.1 to npm.

## Validation

- Publish (manual) GitHub Actions completed successfully.
- npm dist-tag latest resolves to 0.2.1.