### PR TITLE
fix: sync interaction overlay visibility with player controls

### DIFF
--- a/src/components/Slide/Slide.tsx
+++ b/src/components/Slide/Slide.tsx
@@ -227,6 +227,17 @@ const areStepElementListsEqual = (
     );
   });
 
+const TEXT_ENTRY_SELECTOR = [
+  'input:not([type="button"]):not([type="checkbox"]):not([type="radio"]):not([type="submit"])',
+  "textarea",
+  '[contenteditable=""]',
+  '[contenteditable="true"]',
+  '[contenteditable="plaintext-only"]',
+].join(", ");
+
+const isTextEntryTarget = (target: EventTarget | null): target is HTMLElement =>
+  target instanceof HTMLElement && target.matches(TEXT_ENTRY_SELECTOR);
+
 export interface SlideProps extends React.ComponentProps<"section"> {
   elementList?: Element[];
   /** Locale used for built-in UI text when a more specific text prop is not provided. */
@@ -431,6 +442,8 @@ const Slide: React.FC<SlideProps> = ({
     Element | undefined
   >();
   const [isInteractionOverlayOpen, setIsInteractionOverlayOpen] =
+    useState(false);
+  const [hasFocusedInteractionTextInput, setHasFocusedInteractionTextInput] =
     useState(false);
   const [
     interactionOverlaySubtitleOffset,
@@ -1339,6 +1352,7 @@ const Slide: React.FC<SlideProps> = ({
     shouldBlockPlaybackForInteraction,
     playerControlsVisible,
     shouldMountPlayer,
+    hasFocusedTextInput: hasFocusedInteractionTextInput,
   });
 
   const handleInteractionSend = useCallback(
@@ -1380,6 +1394,14 @@ const Slide: React.FC<SlideProps> = ({
       document.removeEventListener("fullscreenchange", syncFullscreenState);
     };
   }, []);
+
+  useEffect(() => {
+    if (activeInteractionElement && isInteractionOverlayOpen) {
+      return;
+    }
+
+    setHasFocusedInteractionTextInput(false);
+  }, [activeInteractionElement, isInteractionOverlayOpen]);
 
   useEffect(() => {
     if (!shouldShowInteractionOverlay) {
@@ -2050,6 +2072,28 @@ const Slide: React.FC<SlideProps> = ({
             )}
             onClick={stopOverlayPropagation}
             onPointerDown={stopOverlayPropagation}
+            onFocusCapture={(event) => {
+              if (isTextEntryTarget(event.target)) {
+                setHasFocusedInteractionTextInput(true);
+              }
+            }}
+            onBlurCapture={(event) => {
+              if (!isTextEntryTarget(event.target)) {
+                return;
+              }
+
+              const nextFocusTarget = event.relatedTarget;
+
+              if (
+                nextFocusTarget instanceof HTMLElement &&
+                interactionOverlayRef.current?.contains(nextFocusTarget) &&
+                isTextEntryTarget(nextFocusTarget)
+              ) {
+                return;
+              }
+
+              setHasFocusedInteractionTextInput(false);
+            }}
             style={interactionOverlayStyle}
           >
             <InteractionOverlayCard

--- a/src/components/Slide/Slide.tsx
+++ b/src/components/Slide/Slide.tsx
@@ -48,7 +48,11 @@ import {
   resolveMobileViewModeState,
   type MobileViewMode,
 } from "./utils/mobileScreenMode";
-import { shouldPresentInteractionOverlay } from "./utils/interactionPlayback";
+<<<<<<< HEAD
+import {
+  shouldPresentInteractionOverlay,
+  shouldRenderInteractionOverlay,
+} from "./utils/interactionPlayback";
 import { resolveMarkdownScalingMode } from "./utils/markdownScaling";
 import { shouldWakePlayerControlsAfterNavigation } from "./utils/playerNavigationContext";
 import { shouldAutoAdvanceIntoAppendedMarker } from "./utils/appendedMarkerAdvance";
@@ -1330,8 +1334,13 @@ const Slide: React.FC<SlideProps> = ({
     Boolean(activeInteractionElement?.readonly) || hasResolvedInteractionInput;
   const shouldAutoContinueInteraction =
     isInteractionReadonly || hasResolvedInteractionInput;
-  const shouldShowInteractionOverlay =
-    Boolean(activeInteractionElement) && isInteractionOverlayOpen;
+  const shouldShowInteractionOverlay = shouldRenderInteractionOverlay({
+    hasActiveInteraction: Boolean(activeInteractionElement),
+    isInteractionOverlayOpen,
+    shouldBlockPlaybackForInteraction,
+    playerControlsVisible,
+    shouldMountPlayer,
+  });
 
   const handleInteractionSend = useCallback(
     (content: OnSendContentParams) => {

--- a/src/components/Slide/Slide.tsx
+++ b/src/components/Slide/Slide.tsx
@@ -48,7 +48,6 @@ import {
   resolveMobileViewModeState,
   type MobileViewMode,
 } from "./utils/mobileScreenMode";
-<<<<<<< HEAD
 import {
   shouldPresentInteractionOverlay,
   shouldRenderInteractionOverlay,

--- a/src/components/Slide/Slide.tsx
+++ b/src/components/Slide/Slide.tsx
@@ -2086,8 +2086,7 @@ const Slide: React.FC<SlideProps> = ({
 
               if (
                 nextFocusTarget instanceof HTMLElement &&
-                interactionOverlayRef.current?.contains(nextFocusTarget) &&
-                isTextEntryTarget(nextFocusTarget)
+                interactionOverlayRef.current?.contains(nextFocusTarget)
               ) {
                 return;
               }

--- a/src/components/Slide/utils/interactionPlayback.test.ts
+++ b/src/components/Slide/utils/interactionPlayback.test.ts
@@ -68,6 +68,7 @@ describe("shouldRenderInteractionOverlay", () => {
         shouldBlockPlaybackForInteraction: true,
         playerControlsVisible: false,
         shouldMountPlayer: true,
+        hasFocusedTextInput: false,
       })
     ).toBe(false);
   });
@@ -80,6 +81,7 @@ describe("shouldRenderInteractionOverlay", () => {
         shouldBlockPlaybackForInteraction: true,
         playerControlsVisible: true,
         shouldMountPlayer: true,
+        hasFocusedTextInput: false,
       })
     ).toBe(true);
   });
@@ -92,6 +94,7 @@ describe("shouldRenderInteractionOverlay", () => {
         shouldBlockPlaybackForInteraction: false,
         playerControlsVisible: false,
         shouldMountPlayer: true,
+        hasFocusedTextInput: false,
       })
     ).toBe(true);
   });
@@ -104,6 +107,7 @@ describe("shouldRenderInteractionOverlay", () => {
         shouldBlockPlaybackForInteraction: true,
         playerControlsVisible: false,
         shouldMountPlayer: false,
+        hasFocusedTextInput: false,
       })
     ).toBe(true);
   });
@@ -116,6 +120,7 @@ describe("shouldRenderInteractionOverlay", () => {
         shouldBlockPlaybackForInteraction: true,
         playerControlsVisible: true,
         shouldMountPlayer: true,
+        hasFocusedTextInput: false,
       })
     ).toBe(false);
   });
@@ -128,7 +133,21 @@ describe("shouldRenderInteractionOverlay", () => {
         shouldBlockPlaybackForInteraction: true,
         playerControlsVisible: true,
         shouldMountPlayer: true,
+        hasFocusedTextInput: false,
       })
     ).toBe(false);
+  });
+
+  it("keeps blocking interactions visible while a text input is focused", () => {
+    expect(
+      shouldRenderInteractionOverlay({
+        hasActiveInteraction: true,
+        isInteractionOverlayOpen: true,
+        shouldBlockPlaybackForInteraction: true,
+        playerControlsVisible: false,
+        shouldMountPlayer: true,
+        hasFocusedTextInput: true,
+      })
+    ).toBe(true);
   });
 });

--- a/src/components/Slide/utils/interactionPlayback.test.ts
+++ b/src/components/Slide/utils/interactionPlayback.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { shouldPresentInteractionOverlay } from "./interactionPlayback";
+import {
+  shouldPresentInteractionOverlay,
+  shouldRenderInteractionOverlay,
+} from "./interactionPlayback";
 
 describe("shouldPresentInteractionOverlay", () => {
   it("keeps unresolved interactions blocking playback", () => {
@@ -53,5 +56,55 @@ describe("shouldPresentInteractionOverlay", () => {
         currentStepHasSpeakableElement: true,
       })
     ).toBe(false);
+  });
+});
+
+describe("shouldRenderInteractionOverlay", () => {
+  it("hides unresolved blocking interactions when player controls auto-hide", () => {
+    expect(
+      shouldRenderInteractionOverlay({
+        hasActiveInteraction: true,
+        isInteractionOverlayOpen: true,
+        shouldBlockPlaybackForInteraction: true,
+        playerControlsVisible: false,
+        shouldMountPlayer: true,
+      })
+    ).toBe(false);
+  });
+
+  it("shows unresolved blocking interactions while player controls are visible", () => {
+    expect(
+      shouldRenderInteractionOverlay({
+        hasActiveInteraction: true,
+        isInteractionOverlayOpen: true,
+        shouldBlockPlaybackForInteraction: true,
+        playerControlsVisible: true,
+        shouldMountPlayer: true,
+      })
+    ).toBe(true);
+  });
+
+  it("keeps resolved or readonly interactions visible even when player controls hide", () => {
+    expect(
+      shouldRenderInteractionOverlay({
+        hasActiveInteraction: true,
+        isInteractionOverlayOpen: true,
+        shouldBlockPlaybackForInteraction: false,
+        playerControlsVisible: false,
+        shouldMountPlayer: true,
+      })
+    ).toBe(true);
+  });
+
+  it("does not hide the overlay when the player is not mounted", () => {
+    expect(
+      shouldRenderInteractionOverlay({
+        hasActiveInteraction: true,
+        isInteractionOverlayOpen: true,
+        shouldBlockPlaybackForInteraction: true,
+        playerControlsVisible: false,
+        shouldMountPlayer: false,
+      })
+    ).toBe(true);
   });
 });

--- a/src/components/Slide/utils/interactionPlayback.test.ts
+++ b/src/components/Slide/utils/interactionPlayback.test.ts
@@ -107,4 +107,28 @@ describe("shouldRenderInteractionOverlay", () => {
       })
     ).toBe(true);
   });
+
+  it("hides the overlay when there is no active interaction", () => {
+    expect(
+      shouldRenderInteractionOverlay({
+        hasActiveInteraction: false,
+        isInteractionOverlayOpen: true,
+        shouldBlockPlaybackForInteraction: true,
+        playerControlsVisible: true,
+        shouldMountPlayer: true,
+      })
+    ).toBe(false);
+  });
+
+  it("hides the overlay when the interaction overlay is closed", () => {
+    expect(
+      shouldRenderInteractionOverlay({
+        hasActiveInteraction: true,
+        isInteractionOverlayOpen: false,
+        shouldBlockPlaybackForInteraction: true,
+        playerControlsVisible: true,
+        shouldMountPlayer: true,
+      })
+    ).toBe(false);
+  });
 });

--- a/src/components/Slide/utils/interactionPlayback.ts
+++ b/src/components/Slide/utils/interactionPlayback.ts
@@ -42,3 +42,33 @@ export const shouldPresentInteractionOverlay = ({
   // keep the overlay closed so the step can continue as normal playback.
   return !currentStepHasSpeakableElement;
 };
+
+interface ShouldRenderInteractionOverlayParams {
+  hasActiveInteraction: boolean;
+  isInteractionOverlayOpen: boolean;
+  shouldBlockPlaybackForInteraction: boolean;
+  playerControlsVisible: boolean;
+  shouldMountPlayer: boolean;
+}
+
+export const shouldRenderInteractionOverlay = ({
+  hasActiveInteraction,
+  isInteractionOverlayOpen,
+  shouldBlockPlaybackForInteraction,
+  playerControlsVisible,
+  shouldMountPlayer,
+}: ShouldRenderInteractionOverlayParams) => {
+  if (!hasActiveInteraction || !isInteractionOverlayOpen) {
+    return false;
+  }
+
+  if (
+    shouldBlockPlaybackForInteraction &&
+    shouldMountPlayer &&
+    !playerControlsVisible
+  ) {
+    return false;
+  }
+
+  return true;
+};

--- a/src/components/Slide/utils/interactionPlayback.ts
+++ b/src/components/Slide/utils/interactionPlayback.ts
@@ -43,7 +43,7 @@ export const shouldPresentInteractionOverlay = ({
   return !currentStepHasSpeakableElement;
 };
 
-interface ShouldRenderInteractionOverlayParams {
+export interface ShouldRenderInteractionOverlayParams {
   hasActiveInteraction: boolean;
   isInteractionOverlayOpen: boolean;
   shouldBlockPlaybackForInteraction: boolean;

--- a/src/components/Slide/utils/interactionPlayback.ts
+++ b/src/components/Slide/utils/interactionPlayback.ts
@@ -49,6 +49,7 @@ export interface ShouldRenderInteractionOverlayParams {
   shouldBlockPlaybackForInteraction: boolean;
   playerControlsVisible: boolean;
   shouldMountPlayer: boolean;
+  hasFocusedTextInput: boolean;
 }
 
 export const shouldRenderInteractionOverlay = ({
@@ -57,9 +58,14 @@ export const shouldRenderInteractionOverlay = ({
   shouldBlockPlaybackForInteraction,
   playerControlsVisible,
   shouldMountPlayer,
+  hasFocusedTextInput,
 }: ShouldRenderInteractionOverlayParams) => {
   if (!hasActiveInteraction || !isInteractionOverlayOpen) {
     return false;
+  }
+
+  if (hasFocusedTextInput) {
+    return true;
   }
 
   if (


### PR DESCRIPTION
Changed:
- made unresolved blocking interaction overlays follow player auto-hide visibility in Slide
- kept a text-entry interaction overlay visible while its input stays focused
- added focused tests for the player-visibility and focused-input overlay rules

Benefit:
- listen mode no longer leaves the interaction overlay covering subtitles after player controls auto-hide
- learners can keep typing without the active interaction disappearing mid-input
- tapping the screen restores both controls and the active interaction overlay together

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interaction overlay visibility logic during playback, including correct handling when the overlay is closed or there’s no active interaction.
  * Unresolved blocking interactions are now hidden when player controls auto-hide, while resolved/readonly interactions remain visible as expected.
  * The overlay stays visible when focus is inside a text input within the interaction overlay, and continues working correctly when the player is not mounted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->