### PR TITLE
feat: scale markdown slides to the viewport

### DIFF
--- a/src/components/ContentRender/CodeBlock.css
+++ b/src/components/ContentRender/CodeBlock.css
@@ -19,7 +19,7 @@
 }
 
 .language-name {
-  font-size: 12px;
+  font-size: calc(var(--content-render-font-size, 16px) * 0.75);
   color: #6c757d; /* Muted text color */
   font-weight: 500;
   text-transform: lowercase; /* Often looks cleaner for langs like 'ts', 'js' */
@@ -35,7 +35,7 @@
   cursor: pointer;
   padding: 2px 4px;
   border-radius: 4px;
-  font-size: 12px;
+  font-size: calc(var(--content-render-font-size, 16px) * 0.75);
   transition: color 0.2s ease;
   font-family: inherit;
 }
@@ -45,14 +45,16 @@
 }
 
 .copy-icon {
-  width: 14px; /* Smaller icon */
-  height: 14px;
+  width: calc(var(--content-render-font-size, 16px) * 0.875); /* Smaller icon */
+  height: calc(var(--content-render-font-size, 16px) * 0.875);
 }
 
 .code-block-container pre {
   margin: 0 !important;
   padding: 12px 16px 16px 16px; /* Adjust padding to balance header */
   overflow-x: auto;
-  font-size: 13px; /* Slightly smaller font for the code itself if desired, or keep inherited */
+  font-size: calc(
+    var(--content-render-font-size, 16px) * 0.8125
+  ); /* Slightly smaller font for the code itself if desired, or keep inherited */
   background-color: transparent !important; /* Ensure pre doesn't have its own background */
 }

--- a/src/components/ContentRender/IframeSandbox.tsx
+++ b/src/components/ContentRender/IframeSandbox.tsx
@@ -724,7 +724,7 @@ const IframeSandbox: React.FC<IframeSandboxProps> = ({
     shouldEnableScaling,
   ]);
   const containerClassName = [
-    "w-full relative content-render-iframe-sandbox",
+    `w-full relative content-render-iframe-sandbox content-render-iframe-sandbox--${type}`,
     isBlackboardMode
       ? "h-full overflow-auto flex flex-col"
       : contentModeStyle

--- a/src/components/ContentRender/IframeSandbox.tsx
+++ b/src/components/ContentRender/IframeSandbox.tsx
@@ -27,17 +27,14 @@ import type { MarkdownFlowLocale } from "../../lib/locale";
 import { getContentRenderLocaleTexts } from "./contentRenderI18n";
 import { CJK_SAFE_SANS_FONT_FAMILY } from "./cjkFontFamily";
 
-type InjectBlackboardLibraries =
-  typeof import("./blackboard-vendor").injectBlackboardLibraries;
+type BlackboardVendorModule = typeof import("./blackboard-vendor");
 
 // Cache the sandbox vendor loader so every iframe reuses the same preload request.
-let blackboardVendorPromise: Promise<InjectBlackboardLibraries> | null = null;
+let blackboardVendorPromise: Promise<BlackboardVendorModule> | null = null;
 
 const loadBlackboardVendor = () => {
   if (!blackboardVendorPromise) {
-    blackboardVendorPromise = import("./blackboard-vendor").then(
-      (m) => m.injectBlackboardLibraries
-    );
+    blackboardVendorPromise = import("./blackboard-vendor");
   }
 
   return blackboardVendorPromise;
@@ -577,9 +574,9 @@ const IframeSandbox: React.FC<IframeSandboxProps> = ({
     if (shouldInjectSandboxVendor) {
       // Inject Tailwind/DaisyUI/GSAP before rendering sandbox content to avoid FOUC.
       loadBlackboardVendor()
-        .then((inject) => {
+        .then(({ injectBlackboardLibraries }) => {
           if (isDestroyed) return;
-          inject(doc);
+          injectBlackboardLibraries(doc);
           if (shouldEnableScaling) {
             injectScalingSystem(doc);
           }
@@ -594,6 +591,87 @@ const IframeSandbox: React.FC<IframeSandboxProps> = ({
         });
     }
 
+    const hostElement = containerRef.current;
+    let needsTailwindRefreshAfterHidden = Boolean(
+      hostElement &&
+        (hostElement.clientWidth <= 0 || hostElement.clientHeight <= 0)
+    );
+    let isTailwindRefreshQueued = false;
+    let tailwindRefreshFrame: number | null = null;
+    let tailwindRefreshTimer: number | null = null;
+    const runPostTailwindRefreshLayout = () => {
+      if (isDestroyed) return;
+      scheduleHeightUpdate();
+      const iframeWin = iframe.contentWindow as ScalingWindow | null;
+      iframeWin?.__mdf_triggerFitContent?.();
+    };
+    const isHostVisible = () =>
+      Boolean(
+        hostElement &&
+          hostElement.clientWidth > 0 &&
+          hostElement.clientHeight > 0
+      );
+    const queueTailwindRefreshAfterHidden = () => {
+      if (
+        !shouldInjectSandboxVendor ||
+        !hostElement ||
+        !needsTailwindRefreshAfterHidden ||
+        isTailwindRefreshQueued ||
+        !isHostVisible()
+      ) {
+        return;
+      }
+
+      isTailwindRefreshQueued = true;
+      loadBlackboardVendor()
+        .then(({ refreshTailwindRuntime }) => {
+          if (isDestroyed) return;
+
+          tailwindRefreshFrame = window.requestAnimationFrame(() => {
+            tailwindRefreshFrame = null;
+            isTailwindRefreshQueued = false;
+
+            const sandboxContainer = doc.querySelector(".sandbox-container");
+            if (
+              isDestroyed ||
+              !isHostVisible() ||
+              !sandboxContainer?.childNodes.length ||
+              !refreshTailwindRuntime(doc)
+            ) {
+              return;
+            }
+
+            needsTailwindRefreshAfterHidden = false;
+            runPostTailwindRefreshLayout();
+            tailwindRefreshTimer = window.setTimeout(() => {
+              tailwindRefreshTimer = null;
+              runPostTailwindRefreshLayout();
+            }, 100);
+          });
+        })
+        .catch(() => {
+          isTailwindRefreshQueued = false;
+        });
+    };
+    const hostResizeObserver =
+      shouldInjectSandboxVendor && hostElement
+        ? new ResizeObserver((entries) => {
+            const contentRect = entries[0]?.contentRect;
+            const hostWidth = contentRect?.width ?? hostElement.clientWidth;
+            const hostHeight = contentRect?.height ?? hostElement.clientHeight;
+            const isHostSizeVisible = hostWidth > 0 && hostHeight > 0;
+
+            if (!isHostSizeVisible) {
+              return;
+            }
+
+            queueTailwindRefreshAfterHidden();
+          })
+        : null;
+    if (hostResizeObserver && hostElement) {
+      hostResizeObserver.observe(hostElement);
+    }
+
     const resizeObserver = new ResizeObserver(() => updateHeight());
     resizeObserver.observe(doc.body);
     if (rootEl) {
@@ -604,6 +682,11 @@ const IframeSandbox: React.FC<IframeSandboxProps> = ({
     // (e.g. content injected by scripts, images loading, dynamic rendering)
     const mutationObserver = new MutationObserver(() => {
       scheduleHeightUpdate();
+      if (!isHostVisible()) {
+        needsTailwindRefreshAfterHidden = true;
+        return;
+      }
+      queueTailwindRefreshAfterHidden();
     });
     mutationObserver.observe(doc.body, {
       childList: true,
@@ -614,8 +697,15 @@ const IframeSandbox: React.FC<IframeSandboxProps> = ({
 
     return () => {
       isDestroyed = true;
+      hostResizeObserver?.disconnect();
       resizeObserver.disconnect();
       mutationObserver.disconnect();
+      if (tailwindRefreshFrame !== null) {
+        window.cancelAnimationFrame(tailwindRefreshFrame);
+      }
+      if (tailwindRefreshTimer !== null) {
+        window.clearTimeout(tailwindRefreshTimer);
+      }
       if (shouldEnableScaling) {
         const iframeWin = iframe.contentWindow as ScalingWindow | null;
         iframeWin?.__mdf_cleanupScaling?.();

--- a/src/components/ContentRender/IframeSandbox.tsx
+++ b/src/components/ContentRender/IframeSandbox.tsx
@@ -653,8 +653,9 @@ const IframeSandbox: React.FC<IframeSandboxProps> = ({
           isTailwindRefreshQueued = false;
         });
     };
+    const canObserveResize = typeof ResizeObserver !== "undefined";
     const hostResizeObserver =
-      shouldInjectSandboxVendor && hostElement
+      shouldInjectSandboxVendor && hostElement && canObserveResize
         ? new ResizeObserver((entries) => {
             const contentRect = entries[0]?.contentRect;
             const hostWidth = contentRect?.width ?? hostElement.clientWidth;
@@ -672,10 +673,12 @@ const IframeSandbox: React.FC<IframeSandboxProps> = ({
       hostResizeObserver.observe(hostElement);
     }
 
-    const resizeObserver = new ResizeObserver(() => updateHeight());
-    resizeObserver.observe(doc.body);
+    const resizeObserver = canObserveResize
+      ? new ResizeObserver(() => updateHeight())
+      : null;
+    resizeObserver?.observe(doc.body);
     if (rootEl) {
-      resizeObserver.observe(rootEl);
+      resizeObserver?.observe(rootEl);
     }
 
     // MutationObserver: detect DOM changes that ResizeObserver might miss
@@ -698,7 +701,7 @@ const IframeSandbox: React.FC<IframeSandboxProps> = ({
     return () => {
       isDestroyed = true;
       hostResizeObserver?.disconnect();
-      resizeObserver.disconnect();
+      resizeObserver?.disconnect();
       mutationObserver.disconnect();
       if (tailwindRefreshFrame !== null) {
         window.cancelAnimationFrame(tailwindRefreshFrame);

--- a/src/components/ContentRender/IframeSandbox.tsx
+++ b/src/components/ContentRender/IframeSandbox.tsx
@@ -109,7 +109,7 @@ const replaceRootScreenHeightWithFullClass = (
   );
 };
 
-const IframeSandbox: React.FC<IframeSandboxProps> = ({
+const IframeSandboxInstance: React.FC<IframeSandboxProps> = ({
   content,
   type,
   className,
@@ -716,11 +716,13 @@ const IframeSandbox: React.FC<IframeSandboxProps> = ({
       if (shouldBridgeSandboxInteraction) {
         doc.removeEventListener("click", handleSandboxClick, true);
       }
+      if (rootRef.current === root) {
+        rootRef.current = null;
+        updateHeightRef.current = () => {};
+      }
       // Defer unmount to avoid React warning when parent is mid-render
       setTimeout(() => {
         root.unmount();
-        rootRef.current = null;
-        updateHeightRef.current = () => {};
       }, 0);
     };
   }, []);
@@ -738,6 +740,10 @@ const IframeSandbox: React.FC<IframeSandboxProps> = ({
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
+    if (typeof ResizeObserver === "undefined") {
+      setContainerWidth(el.clientWidth);
+      return;
+    }
     const ro = new ResizeObserver((entries) => {
       setContainerWidth(entries[0]?.contentRect.width ?? el.clientWidth);
     });
@@ -800,6 +806,10 @@ const IframeSandbox: React.FC<IframeSandboxProps> = ({
     const t1 = setTimeout(() => updateHeightRef.current?.(), 100);
     const t2 = setTimeout(() => updateHeightRef.current?.(), 500);
     return () => {
+      if (initialPaintFrameRef.current !== null) {
+        window.cancelAnimationFrame(initialPaintFrameRef.current);
+        initialPaintFrameRef.current = null;
+      }
       clearTimeout(t1);
       clearTimeout(t2);
     };
@@ -880,6 +890,18 @@ const IframeSandbox: React.FC<IframeSandboxProps> = ({
       )}
     </div>
   );
+};
+
+const IframeSandbox: React.FC<IframeSandboxProps> = (props) => {
+  const mode = props.mode ?? "content";
+  const shouldEnableScaling = Boolean(
+    props.enableScaling && mode === "blackboard" && props.type === "sandbox"
+  );
+  // The iframe shell captures these initialization-only values. Remounting the
+  // inner instance keeps old and new React roots from sharing cleanup refs.
+  const lifecycleKey = `${props.type}:${mode}:${shouldEnableScaling ? "scaled" : "unscaled"}`;
+
+  return <IframeSandboxInstance key={lifecycleKey} {...props} />;
 };
 
 export default IframeSandbox;

--- a/src/components/ContentRender/blackboard-vendor.ts
+++ b/src/components/ContentRender/blackboard-vendor.ts
@@ -1,13 +1,9 @@
 import tailwindScript from "./vendor/tailwindcss-v3.min.js?raw";
 import daisyuiCss from "./vendor/daisyui-v4.min.css?raw";
 import gsapScript from "./vendor/gsap-v3.min.js?raw";
-import { addCjkSafeSansToTailwindConfig } from "./cjkFontFamily";
+import { refreshTailwindRuntime } from "./utils/tailwind-runtime";
 
-interface TailwindRuntimeWindow extends Window {
-  tailwind?: {
-    config?: unknown;
-  };
-}
+export { refreshTailwindRuntime };
 
 /**
  * Inject blackboard-mode libraries (Tailwind CSS, DaisyUI, GSAP)
@@ -20,13 +16,7 @@ export function injectBlackboardLibraries(doc: Document): void {
   // The Play CDN script replaces window.tailwind with its Proxy during execution,
   // so configure that runtime only after the synchronous append completes.
   doc.head.appendChild(tailwindEl);
-  const tailwindRuntime = (doc.defaultView as TailwindRuntimeWindow | null)
-    ?.tailwind;
-  if (tailwindRuntime) {
-    tailwindRuntime.config = addCjkSafeSansToTailwindConfig(
-      tailwindRuntime.config
-    );
-  }
+  refreshTailwindRuntime(doc);
 
   // 2. DaisyUI v4 CSS
   const daisyuiEl = doc.createElement("style");

--- a/src/components/ContentRender/contentRender.css
+++ b/src/components/ContentRender/contentRender.css
@@ -2,9 +2,11 @@
   --content-render-font-family:
     "Charter", "PingFang SC", "Microsoft YaHei", "Source Han Sans SC",
     sans-serif;
+  --content-render-font-size: var(--mdf-slide-font-size, 16px);
+  --content-render-line-height: var(--mdf-slide-line-height, 30px);
   font-family: var(--content-render-font-family);
   min-width: 0;
-  line-height: 30px;
+  line-height: var(--content-render-line-height);
   word-break: break-word;
   overflow-wrap: break-word;
   hyphens: auto;
@@ -18,10 +20,10 @@
   color: rgba(0, 0, 0, 0.8);
   text-align: justify;
   font-family: var(--content-render-font-family);
-  font-size: 16px;
+  font-size: var(--content-render-font-size);
   font-style: normal;
   font-weight: var(--font-weight-normal, 400);
-  line-height: 30px;
+  line-height: var(--content-render-line-height);
   width: 100%;
 }
 
@@ -236,7 +238,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   font-family: inherit;
-  font-size: 16px;
+  font-size: var(--content-render-font-size);
   font-style: normal;
   font-weight: var(--font-weight-normal, 400);
   line-height: var(--text-sm-line-height, 20px); /* 125% */
@@ -249,7 +251,7 @@
 .content-render .single-select-container button {
   color: var(--base-foreground, #0a0a0a);
   font-family: inherit;
-  font-size: 14px;
+  font-size: calc(var(--content-render-font-size) * 0.875);
   font-style: normal;
   font-weight: 400;
   line-height: var(--text-xs-line-height, 16px); /* 114.286% */
@@ -286,7 +288,7 @@
       var(--shadow-sm-2-color, rgba(0, 0, 0, 0.1));
   color: var(--base-primary-foreground, #fafafa);
   font-family: inherit;
-  font-size: 14px;
+  font-size: calc(var(--content-render-font-size) * 0.875);
   font-style: normal;
   font-weight: var(--font-weight-semibold, 600);
   line-height: var(--text-xs-line-height, 16px);
@@ -308,7 +310,10 @@
   color: var(--base-foreground, #0a0a0a);
   /* text-sm/leading-none/medium */
   font-family: inherit;
-  font-size: var(--text-sm-font-size, 14px);
+  font-size: var(
+    --text-sm-font-size,
+    calc(var(--content-render-font-size) * 0.875)
+  );
   font-style: normal;
   font-weight: var(--font-weight-medium, 500);
   line-height: 100%; /* 14px */
@@ -322,7 +327,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   font-family: inherit;
-  font-size: 16px;
+  font-size: var(--content-render-font-size);
   font-style: normal;
   font-weight: var(--font-weight-normal, 400);
   line-height: var(--text-sm-line-height, 20px);
@@ -367,7 +372,7 @@
   background-color: var(--primary, #2563eb);
   color: var(--base-primary-foreground, #fafafa);
   font-family: inherit;
-  font-size: 14px;
+  font-size: calc(var(--content-render-font-size) * 0.875);
   font-style: normal;
   font-weight: var(--font-weight-semibold, 600);
   line-height: var(--text-xs-line-height, 16px);

--- a/src/components/ContentRender/contentRender.css
+++ b/src/components/ContentRender/contentRender.css
@@ -4,6 +4,7 @@
     sans-serif;
   --content-render-font-size: var(--mdf-slide-font-size, 16px);
   --content-render-line-height: var(--mdf-slide-line-height, 30px);
+
   font-family: var(--content-render-font-family);
   min-width: 0;
   line-height: var(--content-render-line-height);

--- a/src/components/ContentRender/utils/iframe-scaling.ts
+++ b/src/components/ContentRender/utils/iframe-scaling.ts
@@ -8,6 +8,15 @@
  * 4. ResizeObserver / MutationObserver keep everything in sync.
  */
 
+import {
+  PRESENTATION_DEFAULT_FONT_SIZE_PX,
+  PRESENTATION_HEIGHT_FONT_RATIO,
+  PRESENTATION_MIN_BASE_FONT_SIZE_PX,
+  PRESENTATION_MIN_FONT_SIZE_PX,
+  PRESENTATION_OVERFLOW_TOLERANCE_PX,
+  PRESENTATION_WIDTH_FONT_DIVISOR,
+} from "./presentation-scaling";
+
 /** Window extension for the scaling system injected into the iframe. */
 export interface ScalingWindow extends Window {
   __mdf_triggerFitContent?: () => void;
@@ -16,7 +25,7 @@ export interface ScalingWindow extends Window {
 
 const SCALING_CSS = `
 /* Gamma-style scaling base */
-:root { --mdf-fs: 16px; }
+:root { --mdf-fs: ${PRESENTATION_DEFAULT_FONT_SIZE_PX}px; }
 
 *, *::before, *::after {
   box-sizing: border-box;
@@ -46,10 +55,10 @@ html, body {
 const SCALING_JS = `
 !function() {
   var fitTimer = null;
-  var baseFontSize = 16;
+  var baseFontSize = ${PRESENTATION_DEFAULT_FONT_SIZE_PX};
   var compressionRatio = 1;
   var lastCompressTime = 0;
-  var MIN_FONT_PX = 8;
+  var MIN_FONT_PX = ${PRESENTATION_MIN_FONT_SIZE_PX};
 
   function applyFs(fs) {
     document.documentElement.style.setProperty('--mdf-fs', fs + 'px');
@@ -66,8 +75,8 @@ const SCALING_JS = `
     var naturalH = slide.offsetHeight;
     var naturalW = slide.scrollWidth;
 
-    var overflowH = naturalH > viewH + 4;
-    var overflowW = naturalW > viewW + 4;
+    var overflowH = naturalH > viewH + ${PRESENTATION_OVERFLOW_TOLERANCE_PX};
+    var overflowW = naturalW > viewW + ${PRESENTATION_OVERFLOW_TOLERANCE_PX};
 
     if (overflowH || overflowW) {
       var now = Date.now();
@@ -102,7 +111,10 @@ const SCALING_JS = `
   function syncFs() {
     var w = document.documentElement.clientWidth;
     var h = document.documentElement.clientHeight;
-    baseFontSize = Math.min(Math.max(12, w / 48), h * 0.03);
+    baseFontSize = Math.min(
+      Math.max(${PRESENTATION_MIN_BASE_FONT_SIZE_PX}, w / ${PRESENTATION_WIDTH_FONT_DIVISOR}),
+      h * ${PRESENTATION_HEIGHT_FONT_RATIO}
+    );
     applyFs(Math.max(baseFontSize * compressionRatio, MIN_FONT_PX));
     clearTimeout(fitTimer);
     fitTimer = setTimeout(fitContent, 60);

--- a/src/components/ContentRender/utils/presentation-scaling.test.ts
+++ b/src/components/ContentRender/utils/presentation-scaling.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  fitPresentationFontSize,
+  PRESENTATION_DEFAULT_FONT_SIZE_PX,
+  PRESENTATION_MIN_FONT_SIZE_PX,
+  presentationContentFits,
+  resolvePresentationBaseFontSize,
+  resolvePresentationCompressionRatio,
+} from "./presentation-scaling";
+
+describe("presentation scaling", () => {
+  it("uses the same viewport-driven base font-size as HTML slides", () => {
+    expect(
+      resolvePresentationBaseFontSize({ width: 1920, height: 1080 })
+    ).toBeCloseTo(32.4);
+    expect(
+      resolvePresentationBaseFontSize({ width: 960, height: 540 })
+    ).toBeCloseTo(16.2);
+    expect(resolvePresentationBaseFontSize({ width: 360, height: 640 })).toBe(
+      12
+    );
+  });
+
+  it("returns a stable default for unusable viewport dimensions", () => {
+    expect(resolvePresentationBaseFontSize({ width: 0, height: 0 })).toBe(
+      PRESENTATION_DEFAULT_FONT_SIZE_PX
+    );
+    expect(
+      resolvePresentationBaseFontSize({ width: Number.NaN, height: 600 })
+    ).toBe(PRESENTATION_DEFAULT_FONT_SIZE_PX);
+  });
+
+  it("treats the shared overflow tolerance as fitting", () => {
+    expect(
+      presentationContentFits(
+        { width: 1000, height: 600 },
+        { width: 1004, height: 604 }
+      )
+    ).toBe(true);
+    expect(
+      presentationContentFits(
+        { width: 1000, height: 600 },
+        { width: 1005, height: 604 }
+      )
+    ).toBe(false);
+  });
+
+  it("compresses by the tighter overflowing dimension", () => {
+    expect(
+      resolvePresentationCompressionRatio({
+        baseFontSize: 32,
+        viewport: { width: 1000, height: 600 },
+        content: { width: 2000, height: 900 },
+      })
+    ).toBe(0.5);
+  });
+
+  it("never compresses below the shared minimum font-size", () => {
+    const baseFontSize = 32;
+    const ratio = resolvePresentationCompressionRatio({
+      baseFontSize,
+      viewport: { width: 1000, height: 600 },
+      content: { width: 10000, height: 10000 },
+    });
+
+    expect(baseFontSize * ratio).toBe(PRESENTATION_MIN_FONT_SIZE_PX);
+  });
+
+  it("iterates from the base size and recovers after dense content is replaced", () => {
+    const viewport = { width: 1920, height: 1080 };
+    const denseFontSize = fitPresentationFontSize({
+      viewport,
+      measure: (fontSize) => ({
+        width: 1600,
+        height: fontSize * 50,
+      }),
+    });
+    const sparseFontSize = fitPresentationFontSize({
+      viewport,
+      measure: (fontSize) => ({
+        width: 800,
+        height: fontSize * 10,
+      }),
+    });
+
+    expect(denseFontSize).toBeCloseTo(21.6);
+    expect(sparseFontSize).toBeCloseTo(32.4);
+  });
+});

--- a/src/components/ContentRender/utils/presentation-scaling.ts
+++ b/src/components/ContentRender/utils/presentation-scaling.ts
@@ -1,0 +1,137 @@
+export const PRESENTATION_DEFAULT_FONT_SIZE_PX = 16;
+export const PRESENTATION_MIN_BASE_FONT_SIZE_PX = 12;
+export const PRESENTATION_MIN_FONT_SIZE_PX = 8;
+export const PRESENTATION_WIDTH_FONT_DIVISOR = 48;
+export const PRESENTATION_HEIGHT_FONT_RATIO = 0.03;
+export const PRESENTATION_OVERFLOW_TOLERANCE_PX = 4;
+
+const MAX_FIT_ITERATIONS = 8;
+const MIN_FONT_SIZE_DELTA_PX = 0.05;
+
+export interface PresentationSize {
+  height: number;
+  width: number;
+}
+
+export interface FitPresentationFontSizeOptions {
+  measure: (fontSize: number) => PresentationSize;
+  viewport: PresentationSize;
+}
+
+const isPositiveFinite = (value: number) => Number.isFinite(value) && value > 0;
+
+/**
+ * Matches the viewport-driven base font-size used by HTML presentation slides.
+ */
+export const resolvePresentationBaseFontSize = ({
+  height,
+  width,
+}: PresentationSize) => {
+  if (!isPositiveFinite(width) || !isPositiveFinite(height)) {
+    return PRESENTATION_DEFAULT_FONT_SIZE_PX;
+  }
+
+  return Math.max(
+    PRESENTATION_MIN_FONT_SIZE_PX,
+    Math.min(
+      Math.max(
+        PRESENTATION_MIN_BASE_FONT_SIZE_PX,
+        width / PRESENTATION_WIDTH_FONT_DIVISOR
+      ),
+      height * PRESENTATION_HEIGHT_FONT_RATIO
+    )
+  );
+};
+
+export const presentationContentFits = (
+  viewport: PresentationSize,
+  content: PresentationSize
+) =>
+  content.height <= viewport.height + PRESENTATION_OVERFLOW_TOLERANCE_PX &&
+  content.width <= viewport.width + PRESENTATION_OVERFLOW_TOLERANCE_PX;
+
+export interface ResolvePresentationCompressionRatioOptions {
+  baseFontSize: number;
+  content: PresentationSize;
+  currentRatio?: number;
+  viewport: PresentationSize;
+}
+
+/**
+ * Returns the next cumulative compression ratio for content that overflows.
+ */
+export const resolvePresentationCompressionRatio = ({
+  baseFontSize,
+  content,
+  currentRatio = 1,
+  viewport,
+}: ResolvePresentationCompressionRatioOptions) => {
+  if (
+    !isPositiveFinite(baseFontSize) ||
+    !isPositiveFinite(viewport.width) ||
+    !isPositiveFinite(viewport.height) ||
+    !isPositiveFinite(content.width) ||
+    !isPositiveFinite(content.height)
+  ) {
+    return 1;
+  }
+
+  const heightRatio =
+    content.height > viewport.height + PRESENTATION_OVERFLOW_TOLERANCE_PX
+      ? viewport.height / content.height
+      : 1;
+  const widthRatio =
+    content.width > viewport.width + PRESENTATION_OVERFLOW_TOLERANCE_PX
+      ? viewport.width / content.width
+      : 1;
+  const minimumRatio = Math.min(
+    1,
+    PRESENTATION_MIN_FONT_SIZE_PX / baseFontSize
+  );
+
+  return Math.max(
+    minimumRatio,
+    Math.min(1, currentRatio * Math.min(heightRatio, widthRatio))
+  );
+};
+
+/**
+ * Applies the presentation font-size through `measure` and iteratively shrinks
+ * it until the content fits or reaches the shared 8px lower bound.
+ */
+export const fitPresentationFontSize = ({
+  measure,
+  viewport,
+}: FitPresentationFontSizeOptions) => {
+  const baseFontSize = resolvePresentationBaseFontSize(viewport);
+  let compressionRatio = 1;
+  let fontSize = baseFontSize;
+
+  for (let iteration = 0; iteration < MAX_FIT_ITERATIONS; iteration += 1) {
+    const content = measure(fontSize);
+
+    if (presentationContentFits(viewport, content)) {
+      return fontSize;
+    }
+
+    const nextCompressionRatio = resolvePresentationCompressionRatio({
+      baseFontSize,
+      content,
+      currentRatio: compressionRatio,
+      viewport,
+    });
+    const nextFontSize = Math.max(
+      PRESENTATION_MIN_FONT_SIZE_PX,
+      baseFontSize * nextCompressionRatio
+    );
+
+    if (Math.abs(nextFontSize - fontSize) < MIN_FONT_SIZE_DELTA_PX) {
+      return nextFontSize;
+    }
+
+    compressionRatio = nextCompressionRatio;
+    fontSize = nextFontSize;
+  }
+
+  return fontSize;
+};

--- a/src/components/ContentRender/utils/tailwind-runtime.test.ts
+++ b/src/components/ContentRender/utils/tailwind-runtime.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { CJK_SAFE_SANS_FONT_FAMILIES } from "../cjkFontFamily";
+import { refreshTailwindRuntime } from "./tailwind-runtime";
+
+describe("refreshTailwindRuntime", () => {
+  it("returns false when the Tailwind Play runtime is unavailable", () => {
+    expect(
+      refreshTailwindRuntime({ defaultView: null } as unknown as Document)
+    ).toBe(false);
+  });
+
+  it("reassigns the config to trigger a JIT rescan and preserves custom config", () => {
+    let assignedConfig: unknown;
+    let currentConfig: unknown = {
+      plugins: ["existing-plugin"],
+      theme: {
+        extend: {
+          colors: { brand: "#0F63EE" },
+        },
+      },
+    };
+    const tailwindRuntime = {
+      get config() {
+        return currentConfig;
+      },
+      set config(value: unknown) {
+        assignedConfig = value;
+        currentConfig = value;
+      },
+    };
+    const doc = {
+      defaultView: { tailwind: tailwindRuntime },
+    } as unknown as Document;
+
+    expect(refreshTailwindRuntime(doc)).toBe(true);
+    expect(assignedConfig).toMatchObject({
+      plugins: ["existing-plugin"],
+      theme: {
+        extend: {
+          colors: { brand: "#0F63EE" },
+          fontFamily: {
+            sans: [...CJK_SAFE_SANS_FONT_FAMILIES],
+          },
+        },
+      },
+    });
+  });
+});

--- a/src/components/ContentRender/utils/tailwind-runtime.ts
+++ b/src/components/ContentRender/utils/tailwind-runtime.ts
@@ -1,0 +1,25 @@
+import { addCjkSafeSansToTailwindConfig } from "../cjkFontFamily";
+
+interface TailwindRuntimeWindow extends Window {
+  tailwind?: {
+    config?: unknown;
+  };
+}
+
+/**
+ * Reassigns the Tailwind Play config so its JIT runtime rescans the iframe DOM.
+ * This is required when a sandbox was initialized under a display:none parent.
+ */
+export const refreshTailwindRuntime = (doc: Document): boolean => {
+  const tailwindRuntime = (doc.defaultView as TailwindRuntimeWindow | null)
+    ?.tailwind;
+
+  if (!tailwindRuntime) {
+    return false;
+  }
+
+  tailwindRuntime.config = addCjkSafeSansToTailwindConfig(
+    tailwindRuntime.config
+  );
+  return true;
+};

--- a/src/components/Slide/MarkdownSlideScaling.tsx
+++ b/src/components/Slide/MarkdownSlideScaling.tsx
@@ -1,0 +1,180 @@
+import React, { useCallback, useEffect, useLayoutEffect, useRef } from "react";
+
+import { cn } from "../../lib/utils";
+import {
+  fitPresentationFontSize,
+  resolvePresentationBaseFontSize,
+} from "../ContentRender/utils/presentation-scaling";
+import type { MarkdownScalingMode } from "./utils/markdownScaling";
+
+const SLIDE_FONT_SIZE_PROPERTY = "--mdf-slide-font-size";
+const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+export interface MarkdownSlideScalingProps
+  extends React.ComponentPropsWithoutRef<"div"> {
+  mode: MarkdownScalingMode;
+}
+
+/**
+ * Fits all Markdown elements in one logical slide with a shared font-size.
+ * Keeping this boundary outside ContentRender lets accumulated title, text,
+ * table, and code elements participate in the same presentation layout.
+ */
+const MarkdownSlideScaling: React.FC<MarkdownSlideScalingProps> = ({
+  children,
+  className,
+  mode,
+  ...props
+}) => {
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const fitFrameRef = useRef<number | null>(null);
+  const isFittingRef = useRef(false);
+
+  const fitContent = useCallback(() => {
+    const viewport = viewportRef.current;
+    const content = contentRef.current;
+
+    if (mode === "disabled" || !viewport || !content || isFittingRef.current) {
+      return;
+    }
+
+    const viewportSize = {
+      height: viewport.clientHeight,
+      width: viewport.clientWidth,
+    };
+
+    if (viewportSize.height <= 0 || viewportSize.width <= 0) {
+      return;
+    }
+
+    isFittingRef.current = true;
+
+    try {
+      const fontSize =
+        mode === "fit"
+          ? fitPresentationFontSize({
+              viewport: viewportSize,
+              measure: (candidateFontSize) => {
+                content.style.setProperty(
+                  SLIDE_FONT_SIZE_PROPERTY,
+                  `${candidateFontSize}px`
+                );
+
+                // Read after the CSS variable update so wrapping and em-based
+                // styles are included in the next compression step.
+                return {
+                  height: content.scrollHeight,
+                  width: content.scrollWidth,
+                };
+              },
+            })
+          : resolvePresentationBaseFontSize(viewportSize);
+
+      content.style.setProperty(SLIDE_FONT_SIZE_PROPERTY, `${fontSize}px`);
+      content.dataset.markdownSlideFontSize = String(fontSize);
+    } finally {
+      isFittingRef.current = false;
+    }
+  }, [mode]);
+
+  const scheduleFit = useCallback(() => {
+    if (mode === "disabled" || fitFrameRef.current !== null) {
+      return;
+    }
+
+    fitFrameRef.current = window.requestAnimationFrame(() => {
+      fitFrameRef.current = null;
+      fitContent();
+    });
+  }, [fitContent, mode]);
+
+  useIsomorphicLayoutEffect(() => {
+    const content = contentRef.current;
+
+    if (!content) {
+      return;
+    }
+
+    if (mode === "disabled") {
+      content.style.removeProperty(SLIDE_FONT_SIZE_PROPERTY);
+      delete content.dataset.markdownSlideFontSize;
+      return;
+    }
+
+    fitContent();
+  }, [fitContent, mode]);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    const content = contentRef.current;
+
+    if (mode === "disabled" || !viewport || !content) {
+      return;
+    }
+
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(scheduleFit);
+    resizeObserver?.observe(viewport);
+
+    const mutationObserver =
+      mode === "fit" && typeof MutationObserver !== "undefined"
+        ? new MutationObserver(scheduleFit)
+        : null;
+
+    if (mode === "fit") {
+      resizeObserver?.observe(content);
+      mutationObserver?.observe(content, {
+        childList: true,
+        characterData: true,
+        subtree: true,
+      });
+      content.addEventListener("load", scheduleFit, true);
+    }
+
+    window.addEventListener("resize", scheduleFit);
+    scheduleFit();
+
+    return () => {
+      resizeObserver?.disconnect();
+      mutationObserver?.disconnect();
+
+      if (mode === "fit") {
+        content.removeEventListener("load", scheduleFit, true);
+      }
+
+      window.removeEventListener("resize", scheduleFit);
+
+      if (fitFrameRef.current !== null) {
+        window.cancelAnimationFrame(fitFrameRef.current);
+        fitFrameRef.current = null;
+      }
+    };
+  }, [mode, scheduleFit]);
+
+  const isScaling = mode !== "disabled";
+
+  return (
+    <div
+      ref={viewportRef}
+      className={cn(className, isScaling && "slide-markdown-scaling")}
+      data-markdown-slide-scaling={isScaling ? mode : undefined}
+      {...props}
+    >
+      <div
+        ref={contentRef}
+        className={cn(
+          "slide-markdown-scaling__content flex w-full flex-col gap-4",
+          mode !== "fit" && "slide-markdown-scaling__content--contents"
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default MarkdownSlideScaling;

--- a/src/components/Slide/MarkdownSlideScaling.tsx
+++ b/src/components/Slide/MarkdownSlideScaling.tsx
@@ -11,8 +11,27 @@ const SLIDE_FONT_SIZE_PROPERTY = "--mdf-slide-font-size";
 const useIsomorphicLayoutEffect =
   typeof window === "undefined" ? useEffect : useLayoutEffect;
 
+interface MarkdownFitSnapshot {
+  contentHeight: number;
+  contentWidth: number;
+  mode: MarkdownScalingMode;
+  viewportHeight: number;
+  viewportWidth: number;
+}
+
+const areFitSnapshotsEqual = (
+  left: MarkdownFitSnapshot,
+  right: MarkdownFitSnapshot
+) =>
+  left.contentHeight === right.contentHeight &&
+  left.contentWidth === right.contentWidth &&
+  left.mode === right.mode &&
+  left.viewportHeight === right.viewportHeight &&
+  left.viewportWidth === right.viewportWidth;
+
 export interface MarkdownSlideScalingProps
   extends React.ComponentPropsWithoutRef<"div"> {
+  /** Controls whether Markdown content is fitted, base-scaled, or unscaled. */
   mode: MarkdownScalingMode;
 }
 
@@ -31,6 +50,7 @@ const MarkdownSlideScaling: React.FC<MarkdownSlideScalingProps> = ({
   const contentRef = useRef<HTMLDivElement>(null);
   const fitFrameRef = useRef<number | null>(null);
   const isFittingRef = useRef(false);
+  const lastFitSnapshotRef = useRef<MarkdownFitSnapshot | null>(null);
 
   const fitContent = useCallback(() => {
     const viewport = viewportRef.current;
@@ -46,6 +66,19 @@ const MarkdownSlideScaling: React.FC<MarkdownSlideScalingProps> = ({
     };
 
     if (viewportSize.height <= 0 || viewportSize.width <= 0) {
+      return;
+    }
+
+    const currentSnapshot: MarkdownFitSnapshot = {
+      contentHeight: content.scrollHeight,
+      contentWidth: content.scrollWidth,
+      mode,
+      viewportHeight: viewportSize.height,
+      viewportWidth: viewportSize.width,
+    };
+    const lastSnapshot = lastFitSnapshotRef.current;
+
+    if (lastSnapshot && areFitSnapshotsEqual(lastSnapshot, currentSnapshot)) {
       return;
     }
 
@@ -74,6 +107,13 @@ const MarkdownSlideScaling: React.FC<MarkdownSlideScalingProps> = ({
 
       content.style.setProperty(SLIDE_FONT_SIZE_PROPERTY, `${fontSize}px`);
       content.dataset.markdownSlideFontSize = String(fontSize);
+      lastFitSnapshotRef.current = {
+        contentHeight: content.scrollHeight,
+        contentWidth: content.scrollWidth,
+        mode,
+        viewportHeight: viewportSize.height,
+        viewportWidth: viewportSize.width,
+      };
     } finally {
       isFittingRef.current = false;
     }
@@ -91,6 +131,11 @@ const MarkdownSlideScaling: React.FC<MarkdownSlideScalingProps> = ({
   }, [fitContent, mode]);
 
   useIsomorphicLayoutEffect(() => {
+    if (fitFrameRef.current !== null) {
+      window.cancelAnimationFrame(fitFrameRef.current);
+      fitFrameRef.current = null;
+    }
+
     const content = contentRef.current;
 
     if (!content) {
@@ -100,6 +145,7 @@ const MarkdownSlideScaling: React.FC<MarkdownSlideScalingProps> = ({
     if (mode === "disabled") {
       content.style.removeProperty(SLIDE_FONT_SIZE_PROPERTY);
       delete content.dataset.markdownSlideFontSize;
+      lastFitSnapshotRef.current = null;
       return;
     }
 
@@ -120,9 +166,13 @@ const MarkdownSlideScaling: React.FC<MarkdownSlideScalingProps> = ({
         : new ResizeObserver(scheduleFit);
     resizeObserver?.observe(viewport);
 
+    const handleContentChange = () => {
+      lastFitSnapshotRef.current = null;
+      scheduleFit();
+    };
     const mutationObserver =
       mode === "fit" && typeof MutationObserver !== "undefined"
-        ? new MutationObserver(scheduleFit)
+        ? new MutationObserver(handleContentChange)
         : null;
 
     if (mode === "fit") {
@@ -132,7 +182,7 @@ const MarkdownSlideScaling: React.FC<MarkdownSlideScalingProps> = ({
         characterData: true,
         subtree: true,
       });
-      content.addEventListener("load", scheduleFit, true);
+      content.addEventListener("load", handleContentChange, true);
     }
 
     window.addEventListener("resize", scheduleFit);
@@ -143,7 +193,7 @@ const MarkdownSlideScaling: React.FC<MarkdownSlideScalingProps> = ({
       mutationObserver?.disconnect();
 
       if (mode === "fit") {
-        content.removeEventListener("load", scheduleFit, true);
+        content.removeEventListener("load", handleContentChange, true);
       }
 
       window.removeEventListener("resize", scheduleFit);

--- a/src/components/Slide/Slide.stories.tsx
+++ b/src/components/Slide/Slide.stories.tsx
@@ -3153,6 +3153,101 @@ export const PreloadedHtmlTailwindRefresh: Story = {
   },
 };
 
+const DynamicSlideContentTypeExample = () => {
+  const [isHtml, setIsHtml] = useState(false);
+  const elementList = useMemo(
+    () => [
+      createExampleElement({
+        sequenceNumber: 32,
+        type: isHtml ? "html" : "text",
+        content: isHtml
+          ? '<div data-dynamic-sandbox-target class="flex h-full w-full items-center justify-center bg-blue-600 p-[4vmin] text-white"><h1 class="text-[5vmin] font-bold">Sandbox initialized</h1></div>'
+          : "# Markdown mode\n\nSwitch to HTML without remounting the surrounding slide element.",
+        isNew: true,
+      }),
+    ],
+    [isHtml]
+  );
+
+  return (
+    <div className="relative h-[100dvh] w-full bg-background p-8">
+      <button
+        type="button"
+        data-dynamic-type-toggle
+        className="absolute right-10 top-10 z-[100] rounded bg-black px-4 py-2 text-white"
+        onClick={() => setIsHtml((current) => !current)}
+      >
+        {isHtml ? "Show Markdown" : "Show HTML"}
+      </button>
+      <Slide
+        className="w-full"
+        elementList={elementList}
+        playerEnabled={false}
+      />
+    </div>
+  );
+};
+
+export const DynamicMarkdownToHtmlSandbox: Story = {
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        story:
+          "Switches one keyed slide element between Markdown and HTML to verify the iframe sandbox initializes on every content-type transition.",
+      },
+    },
+  },
+  render: () => <DynamicSlideContentTypeExample />,
+  play: async ({ canvasElement }) => {
+    expect(canvasElement.querySelector("iframe")).toBeNull();
+
+    const toggle = canvasElement.querySelector(
+      "[data-dynamic-type-toggle]"
+    ) as HTMLButtonElement;
+
+    await userEvent.click(toggle);
+    await waitFor(
+      () => {
+        const iframe = canvasElement.querySelector("iframe");
+        const target = iframe?.contentDocument?.querySelector(
+          "[data-dynamic-sandbox-target]"
+        );
+
+        expect(target).not.toBeNull();
+        expect(getComputedStyle(target as HTMLElement).paddingTop).not.toBe(
+          "0px"
+        );
+      },
+      { timeout: 10000 }
+    );
+
+    await userEvent.click(toggle);
+    await waitFor(() => {
+      expect(canvasElement.querySelector("iframe")).toBeNull();
+      expect(
+        canvasElement.querySelector(".content-render.markdown-body")
+      ).not.toBeNull();
+    });
+
+    await userEvent.click(toggle);
+    await waitFor(
+      () => {
+        const iframe = canvasElement.querySelector("iframe");
+        const target = iframe?.contentDocument?.querySelector(
+          "[data-dynamic-sandbox-target]"
+        );
+
+        expect(target).not.toBeNull();
+        expect(getComputedStyle(target as HTMLElement).paddingTop).not.toBe(
+          "0px"
+        );
+      },
+      { timeout: 10000 }
+    );
+  },
+};
+
 export const FullViewportSingleSlide: Story = {
   args: {
     elementList: [

--- a/src/components/Slide/Slide.stories.tsx
+++ b/src/components/Slide/Slide.stories.tsx
@@ -1,11 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Sparkles } from "lucide-react";
+import { expect, waitFor } from "storybook/test";
 
 import historyFixtureText from "../../../测试历史数据.json?raw";
 import runStreamFixtureText from "../../../测试数据.json?raw";
 import runStreamFixtureText2 from "../../../测试数据2.json?raw";
 import ContentRender from "../ContentRender";
+import { resolvePresentationBaseFontSize } from "../ContentRender/utils/presentation-scaling";
 import type { OnSendContentParams } from "../types";
 import type { SlidePlayerCustomActionContext } from "./types";
 import { getVisibleSubtitleText } from "./utils/subtitleCue";
@@ -86,6 +88,11 @@ const meta = {
       control: { type: "number", min: 0, step: 500 },
       description:
         "Auto-hide delay for player controls in milliseconds after the pointer leaves the control bar",
+    },
+    enableMarkdownScaling: {
+      control: "boolean",
+      description:
+        "Fit Markdown-only slides to the available presentation viewport",
     },
     markerAutoAdvanceDelay: {
       control: { type: "number", min: 0, step: 500 },
@@ -264,6 +271,40 @@ const SLOT_CONTENT = (
 );
 
 const VIDEO_CONTENT = `<iframe data-tag="video" data-title="哔哩哔哩视频" data-url="https://www.bilibili.com/video/BV1ry4y1y7KZ/" class="w-full aspect-video rounded-lg border-0" src="https://player.bilibili.com/player.html?bvid=BV1ry4y1y7KZ&autoplay=0" allowfullscreen="" allow="autoplay; encrypted-media"></iframe>`;
+
+const PRESENTATION_MARKDOWN_CONTENT = [
+  "# Markdown Presentation Scaling",
+  "",
+  "Markdown now uses the same viewport-driven typography as HTML slides. A logical page is measured as one composition, so every block grows and compresses together.",
+  "",
+  "## What stays readable",
+  "",
+  "- Headings and body copy scale from the available width and height.",
+  "- Tables, formulas, diagrams, and code participate in the same fit calculation.",
+  "- Dense pages compress to remain visible and keep scrolling as a final fallback.",
+  "",
+  "| Content | Fullscreen behavior |",
+  "| --- | --- |",
+  "| Text and headings | Scale together |",
+  "| Tables and code | Preserve overflow safety |",
+  "| Mermaid and images | Refit after asynchronous layout |",
+  "",
+  "```typescript",
+  "const fontSize = fitPresentationFontSize({ viewport, measure });",
+  'renderMarkdown({ fontSize, overflowFallback: "scroll" });',
+  "```",
+  "",
+  "The fitting formula starts from $\\min(\\max(12, w / 48), 0.03h)$ and never reduces text below 8px.",
+  "",
+  "```mermaid",
+  "flowchart LR",
+  "  A[Viewport] --> B[Base font size]",
+  "  B --> C{Content fits?}",
+  "  C -->|Yes| D[Present]",
+  "  C -->|No| E[Compress]",
+  "  E --> C",
+  "```",
+].join("\n");
 
 const STREAMING_IFRAME_CONTENT = `<div class="w-full h-screen flex flex-col p-[4vmin] bg-white">
   <div class="flex-1 flex flex-col items-center justify-[safe_center] gap-[4vmin]">
@@ -2750,6 +2791,242 @@ export const FullViewportSlides: Story = {
       ))}
     </div>
   ),
+};
+
+export const FullViewportMarkdownSlide: Story = {
+  args: {
+    elementList: [
+      createExampleElement({
+        sequenceNumber: 30,
+        type: "text",
+        content: PRESENTATION_MARKDOWN_CONTENT,
+        isNew: true,
+      }),
+    ],
+    enableMarkdownScaling: true,
+    playerEnabled: false,
+  },
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        story:
+          "Fits a dense Markdown composition to the full viewport using the same base font-size and overflow compression rules as HTML presentation slides.",
+      },
+    },
+  },
+  render: (args) => (
+    <div className="h-[100dvh] w-full bg-background p-8">
+      <Slide className="w-full" {...args} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    await waitFor(
+      () => {
+        expect(
+          canvasElement.querySelector(
+            ".slide-markdown-scaling[data-markdown-slide-scaling='fit'] .content-render-mermaid svg"
+          )
+        ).not.toBeNull();
+
+        const viewport = canvasElement.querySelector(
+          ".slide-markdown-scaling[data-markdown-slide-scaling='fit']"
+        ) as HTMLElement;
+
+        expect(viewport.scrollWidth).toBeLessThanOrEqual(
+          viewport.clientWidth + 4
+        );
+        expect(viewport.scrollHeight).toBeLessThanOrEqual(
+          viewport.clientHeight + 4
+        );
+      },
+      { timeout: 10000 }
+    );
+
+    const viewport = canvasElement.querySelector(
+      ".slide-markdown-scaling[data-markdown-slide-scaling='fit']"
+    ) as HTMLElement;
+    const content = viewport.querySelector(
+      ":scope > .slide-markdown-scaling__content"
+    ) as HTMLElement;
+    const markdown = viewport.querySelector(
+      ".content-render.markdown-body"
+    ) as HTMLElement;
+    const code = viewport.querySelector(
+      ".code-block-container pre"
+    ) as HTMLElement;
+    const fittedFontSize = Number(content.dataset.markdownSlideFontSize);
+    const baseFontSize = resolvePresentationBaseFontSize({
+      height: viewport.clientHeight,
+      width: viewport.clientWidth,
+    });
+
+    expect(fittedFontSize).toBeLessThan(baseFontSize);
+    expect(parseFloat(getComputedStyle(markdown).fontSize)).toBeCloseTo(
+      fittedFontSize,
+      1
+    );
+    expect(parseFloat(getComputedStyle(code).fontSize)).toBeLessThan(
+      fittedFontSize
+    );
+    expect(viewport.scrollWidth).toBeLessThanOrEqual(viewport.clientWidth + 4);
+    expect(viewport.scrollHeight).toBeLessThanOrEqual(
+      viewport.clientHeight + 4
+    );
+  },
+};
+
+export const FullViewportSparseMarkdownSlide: Story = {
+  args: {
+    elementList: [
+      createExampleElement({
+        sequenceNumber: 29,
+        type: "title",
+        content:
+          "# Responsive Markdown\n\nSparse slides expand their typography to use the available presentation viewport.",
+        isNew: true,
+      }),
+    ],
+    enableMarkdownScaling: true,
+    playerEnabled: false,
+  },
+  parameters: {
+    layout: "fullscreen",
+  },
+  render: (args) => (
+    <div className="h-[100dvh] w-full bg-background p-8">
+      <Slide className="w-full" {...args} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    await waitFor(() => {
+      expect(
+        canvasElement.querySelector(
+          ".slide-markdown-scaling__content[data-markdown-slide-font-size]"
+        )
+      ).not.toBeNull();
+    });
+
+    const viewport = canvasElement.querySelector(
+      ".slide-markdown-scaling[data-markdown-slide-scaling='fit']"
+    ) as HTMLElement;
+    const markdown = viewport.querySelector(
+      ".content-render.markdown-body"
+    ) as HTMLElement;
+
+    expect(parseFloat(getComputedStyle(markdown).fontSize)).toBeGreaterThan(16);
+    expect(viewport.scrollWidth).toBeLessThanOrEqual(viewport.clientWidth + 4);
+    expect(viewport.scrollHeight).toBeLessThanOrEqual(
+      viewport.clientHeight + 4
+    );
+  },
+};
+
+export const FullViewportAccumulatedMarkdownSlide: Story = {
+  args: {
+    elementList: [
+      {
+        ...createExampleElement({
+          sequenceNumber: 26,
+          type: "title",
+          content: "# One logical Markdown slide",
+          isNew: true,
+        }),
+        is_renderable: false,
+      },
+      {
+        ...createExampleElement({
+          sequenceNumber: 27,
+          type: "text",
+          content:
+            "Title, body copy, and code can arrive as separate elements while sharing one presentation-scale calculation.",
+        }),
+        is_renderable: false,
+      },
+      createExampleElement({
+        sequenceNumber: 28,
+        type: "code",
+        content: CODE_CONTENT,
+      }),
+    ],
+    enableMarkdownScaling: true,
+    playerEnabled: false,
+  },
+  parameters: {
+    layout: "fullscreen",
+  },
+  render: (args) => (
+    <div className="h-[100dvh] w-full bg-background p-8">
+      <Slide className="w-full" {...args} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    await waitFor(() => {
+      expect(
+        canvasElement.querySelector(
+          ".slide-markdown-scaling__content[data-markdown-slide-font-size]"
+        )
+      ).not.toBeNull();
+    });
+
+    const viewport = canvasElement.querySelector(
+      ".slide-markdown-scaling[data-markdown-slide-scaling='fit']"
+    ) as HTMLElement;
+    const markdownElements = Array.from(
+      viewport.querySelectorAll(".content-render.markdown-body")
+    ) as HTMLElement[];
+    const fontSizes = markdownElements.map(
+      (element) => getComputedStyle(element).fontSize
+    );
+
+    expect(markdownElements).toHaveLength(3);
+    expect(markdownElements.every((element) => element.offsetParent)).toBe(
+      true
+    );
+    expect(new Set(fontSizes).size).toBe(1);
+  },
+};
+
+export const FullViewportMarkdownSlideWithoutScaling: Story = {
+  args: {
+    elementList: [
+      createExampleElement({
+        sequenceNumber: 25,
+        type: "text",
+        content: PRESENTATION_MARKDOWN_CONTENT,
+        isNew: true,
+      }),
+    ],
+    enableMarkdownScaling: false,
+    playerEnabled: false,
+  },
+  parameters: {
+    layout: "fullscreen",
+  },
+  render: (args) => (
+    <div className="h-[100dvh] w-full bg-background p-8">
+      <Slide className="w-full" {...args} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const markdown = canvasElement.querySelector(
+      ".content-render.markdown-body"
+    ) as HTMLElement;
+    const code = canvasElement.querySelector(
+      ".code-block-container pre"
+    ) as HTMLElement;
+    const language = canvasElement.querySelector(
+      ".code-block-container .language-name"
+    ) as HTMLElement;
+
+    expect(
+      canvasElement.querySelector("[data-markdown-slide-scaling]")
+    ).toBeNull();
+    expect(getComputedStyle(markdown).fontSize).toBe("16px");
+    expect(getComputedStyle(markdown).lineHeight).toBe("30px");
+    expect(getComputedStyle(code).fontSize).toBe("13px");
+    expect(getComputedStyle(language).fontSize).toBe("12px");
+  },
 };
 
 export const FullViewportSingleSlide: Story = {

--- a/src/components/Slide/Slide.stories.tsx
+++ b/src/components/Slide/Slide.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Sparkles } from "lucide-react";
-import { expect, waitFor } from "storybook/test";
+import { expect, userEvent, waitFor } from "storybook/test";
 
 import historyFixtureText from "../../../测试历史数据.json?raw";
 import runStreamFixtureText from "../../../测试数据.json?raw";
@@ -3026,6 +3026,74 @@ export const FullViewportMarkdownSlideWithoutScaling: Story = {
     expect(getComputedStyle(markdown).lineHeight).toBe("30px");
     expect(getComputedStyle(code).fontSize).toBe("13px");
     expect(getComputedStyle(language).fontSize).toBe("12px");
+  },
+};
+
+export const PreloadedHtmlTailwindRefresh: Story = {
+  args: {
+    elementList: [
+      createExampleElement({
+        sequenceNumber: 23,
+        type: "html",
+        content:
+          '<div class="flex h-screen w-full items-center justify-center bg-slate-100 p-[4vmin]"><div class="rounded-[2vmin] bg-white p-[5vmin] text-center shadow-xl"><h1 class="text-[5vmin] font-bold text-slate-900">First HTML slide</h1><p class="mt-[2vmin] text-[2.5vmin] text-slate-600">The next slide starts preloaded under display:none.</p></div></div>',
+        isNew: true,
+      }),
+      {
+        ...createExampleElement({
+          sequenceNumber: 24,
+          type: "html",
+          content:
+            '<div data-tailwind-regression-target class="h-screen w-full bg-gradient-to-br from-blue-600 to-indigo-950 p-[4vmin] text-white"><h1 class="text-[6vmin] font-bold">Preloaded Tailwind restored</h1><div class="mt-[4vmin] grid grid-cols-2 gap-[3vmin]"><div class="rounded-[2vmin] bg-white/20 p-[4vmin] shadow-xl"><h2 class="text-[3.5vmin] font-semibold">Gradient</h2><p class="mt-[1vmin] text-[2.5vmin] text-blue-100">Utilities are compiled after the hidden iframe becomes visible.</p></div><div class="rounded-[2vmin] border border-white/30 bg-white/10 p-[4vmin]"><h2 class="text-[3.5vmin] font-semibold">Spacing</h2><p class="mt-[1vmin] text-[2.5vmin] text-indigo-100">Padding, color, grid, and typography must all remain styled.</p></div></div></div>',
+          isNew: true,
+        }),
+        is_renderable: false,
+      },
+    ],
+    playerControlsVisibility: "visible",
+  },
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        story:
+          "Navigates to an HTML sandbox that was preloaded under display:none and verifies Tailwind Play recompiles its utilities after becoming visible.",
+      },
+    },
+  },
+  render: (args) => (
+    <div className="h-[100dvh] w-full bg-background">
+      <Slide className="w-full" {...args} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const nextButton = canvasElement.querySelector(
+      "button[aria-label='Next page']"
+    ) as HTMLButtonElement;
+
+    await userEvent.click(nextButton);
+    await waitFor(
+      () => {
+        const activeStep = Array.from(
+          canvasElement.querySelectorAll(".slide-stage__layer > div")
+        ).find((element) => getComputedStyle(element).display !== "none");
+        const iframe = activeStep?.querySelector("iframe");
+        const target = iframe?.contentDocument?.querySelector(
+          "[data-tailwind-regression-target]"
+        ) as HTMLElement | null;
+
+        expect(iframe?.clientWidth).toBeGreaterThan(0);
+        expect(iframe?.clientHeight).toBeGreaterThan(0);
+        expect(target).not.toBeNull();
+        expect(getComputedStyle(target as HTMLElement).paddingTop).not.toBe(
+          "0px"
+        );
+        expect(
+          getComputedStyle(target as HTMLElement).backgroundImage
+        ).not.toBe("none");
+      },
+      { timeout: 10000 }
+    );
   },
 };
 

--- a/src/components/Slide/Slide.stories.tsx
+++ b/src/components/Slide/Slide.stories.tsx
@@ -2987,6 +2987,62 @@ export const FullViewportAccumulatedMarkdownSlide: Story = {
   },
 };
 
+export const FullViewportMixedSlideTopAlignment: Story = {
+  args: {
+    elementList: [
+      {
+        ...createExampleElement({
+          sequenceNumber: 30,
+          type: "title",
+          content: "# Mixed slide stays top aligned",
+          isNew: true,
+        }),
+        is_renderable: false,
+      },
+      createExampleElement({
+        sequenceNumber: 31,
+        type: "slot",
+        content: (
+          <div className="rounded-xl border border-blue-200 bg-blue-50 p-6 text-blue-950">
+            Mixed Markdown and slot content uses the viewport base size without
+            changing the existing top-aligned layout.
+          </div>
+        ),
+      }),
+    ],
+    enableMarkdownScaling: true,
+    playerEnabled: false,
+  },
+  parameters: {
+    layout: "fullscreen",
+  },
+  render: (args) => (
+    <div className="h-[100dvh] w-full bg-background p-8">
+      <Slide className="w-full" {...args} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const viewport = await waitFor(() => {
+      const element = canvasElement.querySelector(
+        ".slide-markdown-scaling[data-markdown-slide-scaling='base']"
+      ) as HTMLElement | null;
+
+      expect(element).not.toBeNull();
+      return element as HTMLElement;
+    });
+    const content = viewport.querySelector(
+      ".slide-markdown-scaling__content"
+    ) as HTMLElement;
+    const firstSlideElement = content.firstElementChild as HTMLElement;
+    const topOffset =
+      firstSlideElement.getBoundingClientRect().top -
+      viewport.getBoundingClientRect().top;
+
+    expect(topOffset).toBeGreaterThanOrEqual(-1);
+    expect(topOffset).toBeLessThanOrEqual(4);
+  },
+};
+
 export const FullViewportMarkdownSlideWithoutScaling: Story = {
   args: {
     elementList: [

--- a/src/components/Slide/Slide.stories.tsx
+++ b/src/components/Slide/Slide.stories.tsx
@@ -306,6 +306,88 @@ const PRESENTATION_MARKDOWN_CONTENT = [
   "```",
 ].join("\n");
 
+const FULL_VIEWPORT_CODE_ONLY_CONTENT = [
+  "```typescript",
+  "type Viewport = Readonly<{",
+  "  width: number;",
+  "  height: number;",
+  "}>;",
+  "",
+  "type ContentSize = Readonly<{",
+  "  width: number;",
+  "  height: number;",
+  "}>;",
+  "",
+  "const MIN_FONT_SIZE = 8;",
+  "const MAX_FONT_SIZE = 64;",
+  "const FIT_EPSILON = 0.25;",
+  "",
+  "const fits = (content: ContentSize, viewport: Viewport) =>",
+  "  content.width <= viewport.width &&",
+  "  content.height <= viewport.height;",
+  "",
+  "export function fitMarkdownFontSize(",
+  "  viewport: Viewport,",
+  "  measure: (fontSize: number) => ContentSize",
+  ") {",
+  "  let low = MIN_FONT_SIZE;",
+  "  let high = MAX_FONT_SIZE;",
+  "",
+  "  while (high - low > FIT_EPSILON) {",
+  "    const middle = (low + high) / 2;",
+  "    if (fits(measure(middle), viewport)) {",
+  "      low = middle;",
+  "    } else {",
+  "      high = middle;",
+  "    }",
+  "  }",
+  "",
+  "  return Number(low.toFixed(2));",
+  "}",
+  "",
+  "const fittedFontSize = fitMarkdownFontSize(",
+  "  { width: 1280, height: 720 },",
+  "  (fontSize) => ({",
+  "    width: fontSize * 34,",
+  "    height: fontSize * 18,",
+  "  })",
+  ");",
+  "",
+  "console.log({ fittedFontSize });",
+  "```",
+].join("\n");
+
+const FULL_VIEWPORT_HEADING_ONLY_CONTENT = "# Markdown 全屏标题";
+
+const FULL_VIEWPORT_MERMAID_ONLY_CONTENT = [
+  "```mermaid",
+  "flowchart LR",
+  "  A[Markdown source] --> B[Parse AST]",
+  "  B --> C{Block type}",
+  "  C -->|Heading| D[Typography]",
+  "  C -->|Code| E[Syntax highlight]",
+  "  C -->|Math| F[KaTeX]",
+  "  C -->|Diagram| G[Mermaid]",
+  "  D --> H[Measure content]",
+  "  E --> H",
+  "  F --> H",
+  "  G --> H",
+  "  H --> I{Fits viewport?}",
+  "  I -->|No| J[Reduce font size]",
+  "  J --> H",
+  "  I -->|Yes| K[Present slide]",
+  "```",
+].join("\n");
+
+const FULL_VIEWPORT_MATH_ONLY_CONTENT = String.raw`$$
+\begin{aligned}
+e^{i\pi}+1 &= 0 \\
+\frac{d}{dx}\left(x^n\right) &= nx^{n-1} \\
+\int_{-\infty}^{\infty} e^{-x^2}\,dx &= \sqrt{\pi} \\
+\sum_{k=1}^{n} k &= \frac{n(n+1)}{2}
+\end{aligned}
+$$`;
+
 const STREAMING_IFRAME_CONTENT = `<div class="w-full h-screen flex flex-col p-[4vmin] bg-white">
   <div class="flex-1 flex flex-col items-center justify-[safe_center] gap-[4vmin]">
     <h1 class="text-[4vmin] font-bold text-[#0F63EE]">三个常见观点，请你判断</h1>
@@ -2793,6 +2875,72 @@ export const FullViewportSlides: Story = {
   ),
 };
 
+const renderFullViewportMarkdownStory = (
+  args: React.ComponentProps<typeof Slide>
+) => (
+  <div className="h-[100dvh] w-full bg-background p-8">
+    <Slide className="w-full" {...args} />
+  </div>
+);
+
+const waitForFittedMarkdownStory = async (canvasElement: HTMLElement) =>
+  waitFor(() => {
+    const viewport = canvasElement.querySelector(
+      ".slide-markdown-scaling[data-markdown-slide-scaling='fit']"
+    ) as HTMLElement | null;
+    const content = viewport?.querySelector(
+      ":scope > .slide-markdown-scaling__content[data-markdown-slide-font-size]"
+    ) as HTMLElement | null;
+    const markdown = viewport?.querySelector(
+      ".content-render.markdown-body"
+    ) as HTMLElement | null;
+
+    expect(viewport).not.toBeNull();
+    expect(content).not.toBeNull();
+    expect(markdown).not.toBeNull();
+
+    return {
+      content: content as HTMLElement,
+      markdown: markdown as HTMLElement,
+      viewport: viewport as HTMLElement,
+    };
+  });
+
+const expectFittedMarkdownStoryToFit = (viewport: HTMLElement) => {
+  expect(viewport.scrollWidth).toBeLessThanOrEqual(viewport.clientWidth + 4);
+  expect(viewport.scrollHeight).toBeLessThanOrEqual(viewport.clientHeight + 4);
+};
+
+interface FullViewportMarkdownStoryConfig {
+  content: string;
+  description: string;
+  play: NonNullable<Story["play"]>;
+  sequenceNumber: number;
+  type: Element["type"];
+}
+
+const createFullViewportMarkdownStory = ({
+  content,
+  description,
+  play,
+  sequenceNumber,
+  type,
+}: FullViewportMarkdownStoryConfig): Story => ({
+  args: {
+    elementList: [
+      createExampleElement({ sequenceNumber, type, content, isNew: true }),
+    ],
+    enableMarkdownScaling: true,
+    playerEnabled: false,
+  },
+  parameters: {
+    layout: "fullscreen",
+    docs: { description: { story: description } },
+  },
+  render: renderFullViewportMarkdownStory,
+  play,
+});
+
 export const FullViewportMarkdownSlide: Story = {
   args: {
     elementList: [
@@ -2875,6 +3023,128 @@ export const FullViewportMarkdownSlide: Story = {
     );
   },
 };
+
+export const FullViewportCodeOnlyMarkdownSlide =
+  createFullViewportMarkdownStory({
+    sequenceNumber: 33,
+    type: "code",
+    content: FULL_VIEWPORT_CODE_ONLY_CONTENT,
+    description:
+      "Fills one Markdown slide with a dense TypeScript code block to exercise fullscreen compression and syntax highlighting.",
+    play: async ({ canvasElement }) => {
+      const { content, markdown, viewport } =
+        await waitForFittedMarkdownStory(canvasElement);
+      const markdownRenderer = markdown.querySelector(
+        ".markdown-renderer"
+      ) as HTMLElement;
+      const codeBlock = markdownRenderer.querySelector(
+        ":scope > .code-block-container"
+      ) as HTMLElement;
+      const code = codeBlock.querySelector("pre > code") as HTMLElement;
+      const language = codeBlock.querySelector(".language-name") as HTMLElement;
+      const fittedFontSize = Number(content.dataset.markdownSlideFontSize);
+
+      expect(markdownRenderer.children).toHaveLength(1);
+      expect(language.textContent?.trim()).toBe("typescript");
+      expect(code.textContent).toContain("fitMarkdownFontSize");
+      expect(parseFloat(getComputedStyle(code).fontSize)).toBeLessThan(
+        fittedFontSize
+      );
+      expectFittedMarkdownStoryToFit(viewport);
+    },
+  });
+
+export const FullViewportHeadingOnlyMarkdownSlide =
+  createFullViewportMarkdownStory({
+    sequenceNumber: 34,
+    type: "title",
+    content: FULL_VIEWPORT_HEADING_ONLY_CONTENT,
+    description:
+      "Renders exactly one level-one heading so sparse Markdown typography and centering can be inspected in isolation.",
+    play: async ({ canvasElement }) => {
+      const { markdown, viewport } =
+        await waitForFittedMarkdownStory(canvasElement);
+      const markdownRenderer = markdown.querySelector(
+        ".markdown-renderer"
+      ) as HTMLElement;
+      const headings = markdownRenderer.querySelectorAll("h1");
+      const heading = headings[0] as HTMLElement;
+
+      expect(markdownRenderer.children).toHaveLength(1);
+      expect(headings).toHaveLength(1);
+      expect(heading.textContent?.trim()).toBe("Markdown 全屏标题");
+      expect(parseFloat(getComputedStyle(heading).fontSize)).toBeGreaterThan(
+        parseFloat(getComputedStyle(markdown).fontSize)
+      );
+      expectFittedMarkdownStoryToFit(viewport);
+    },
+  });
+
+export const FullViewportMermaidOnlyMarkdownSlide =
+  createFullViewportMarkdownStory({
+    sequenceNumber: 35,
+    type: "mermaid",
+    content: FULL_VIEWPORT_MERMAID_ONLY_CONTENT,
+    description:
+      "Renders one Mermaid diagram without surrounding prose and verifies the asynchronous SVG refits inside the presentation viewport.",
+    play: async ({ canvasElement }) => {
+      const { markdown, viewport } =
+        await waitForFittedMarkdownStory(canvasElement);
+
+      await waitFor(
+        () => {
+          const diagrams = markdown.querySelectorAll(".content-render-mermaid");
+          const svg = markdown.querySelector(
+            ".content-render-mermaid-inner svg"
+          ) as SVGElement | null;
+          const svgRect = svg?.getBoundingClientRect();
+          const viewportRect = viewport.getBoundingClientRect();
+
+          expect(diagrams).toHaveLength(1);
+          expect(svg).not.toBeNull();
+          expect(svgRect?.width).toBeGreaterThan(0);
+          expect(svgRect?.height).toBeGreaterThan(0);
+          expect(svgRect?.left).toBeGreaterThanOrEqual(viewportRect.left - 4);
+          expect(svgRect?.right).toBeLessThanOrEqual(viewportRect.right + 4);
+          expect(markdown.querySelector(".code-block-container")).toBeNull();
+          expectFittedMarkdownStoryToFit(viewport);
+        },
+        { timeout: 10000 }
+      );
+    },
+  });
+
+export const FullViewportMathOnlyMarkdownSlide =
+  createFullViewportMarkdownStory({
+    sequenceNumber: 36,
+    type: "latex",
+    content: FULL_VIEWPORT_MATH_ONLY_CONTENT,
+    description:
+      "Renders one display-math block so KaTeX sizing and fullscreen fitting can be inspected without other Markdown content.",
+    play: async ({ canvasElement }) => {
+      const { markdown, viewport } =
+        await waitForFittedMarkdownStory(canvasElement);
+      const markdownRenderer = markdown.querySelector(
+        ".markdown-renderer"
+      ) as HTMLElement;
+      const displays = markdownRenderer.querySelectorAll(".katex-display");
+      const katex = markdownRenderer.querySelector(
+        ".katex-display > .katex"
+      ) as HTMLElement;
+      const annotation = markdownRenderer.querySelector(
+        ".katex-mathml annotation[encoding='application/x-tex']"
+      );
+
+      expect(markdownRenderer.children).toHaveLength(1);
+      expect(displays).toHaveLength(1);
+      expect(annotation?.textContent).toContain("\\begin{aligned}");
+      expect(markdownRenderer.querySelector(".katex-error")).toBeNull();
+      expect(parseFloat(getComputedStyle(katex).fontSize)).toBeGreaterThan(
+        parseFloat(getComputedStyle(markdown).fontSize)
+      );
+      expectFittedMarkdownStoryToFit(viewport);
+    },
+  });
 
 export const FullViewportSparseMarkdownSlide: Story = {
   args: {

--- a/src/components/Slide/Slide.tsx
+++ b/src/components/Slide/Slide.tsx
@@ -28,6 +28,7 @@ import {
   subscribeMobileDeviceChange,
 } from "../../lib/mobileDevice";
 import Player from "./Player";
+import MarkdownSlideScaling from "./MarkdownSlideScaling";
 import SubtitleOverlay from "./SubtitleOverlay";
 import type {
   PlayerProps,
@@ -48,6 +49,7 @@ import {
   type MobileViewMode,
 } from "./utils/mobileScreenMode";
 import { shouldPresentInteractionOverlay } from "./utils/interactionPlayback";
+import { resolveMarkdownScalingMode } from "./utils/markdownScaling";
 import { shouldWakePlayerControlsAfterNavigation } from "./utils/playerNavigationContext";
 import { shouldAutoAdvanceIntoAppendedMarker } from "./utils/appendedMarkerAdvance";
 import {
@@ -269,6 +271,13 @@ export interface SlideProps extends React.ComponentProps<"section"> {
    */
   enableKeyboardShortcuts?: boolean;
   enableIframeScaling?: boolean;
+  /**
+   * Fits Markdown-only slides to the available presentation viewport.
+   *
+   * Defaults to `true`. Disable this to preserve the fixed 16px article
+   * typography used by standalone ContentRender.
+   */
+  enableMarkdownScaling?: boolean;
   disableLoadingOverlay?: boolean;
 }
 
@@ -294,6 +303,7 @@ const Slide: React.FC<SlideProps> = ({
   onStepChange,
   enableKeyboardShortcuts = true,
   enableIframeScaling = true,
+  enableMarkdownScaling = true,
   disableLoadingOverlay = false,
   className,
   onPointerDown,
@@ -1480,6 +1490,10 @@ const Slide: React.FC<SlideProps> = ({
     const visibleElementCount = elementList.filter(
       (element) => element.is_renderable !== false
     ).length;
+    const markdownScalingMode =
+      isActiveStep && enableMarkdownScaling
+        ? resolveMarkdownScalingMode(elementList)
+        : "disabled";
     const lastVisibleElementIndex = elementList.reduce(
       (lastVisibleIndex, element, index) =>
         element.is_renderable !== false ? index : lastVisibleIndex,
@@ -1487,7 +1501,10 @@ const Slide: React.FC<SlideProps> = ({
     );
 
     return (
-      <div className="slide-stage__content flex w-full flex-col gap-4">
+      <MarkdownSlideScaling
+        className="slide-stage__content flex w-full flex-col gap-4"
+        mode={markdownScalingMode}
+      >
         {elementList.map((element, index) => {
           const isPreRenderedHtml =
             element.type === "html" && element.is_renderable === false;
@@ -1520,7 +1537,7 @@ const Slide: React.FC<SlideProps> = ({
             </div>
           );
         })}
-      </div>
+      </MarkdownSlideScaling>
     );
   };
 

--- a/src/components/Slide/slide.css
+++ b/src/components/Slide/slide.css
@@ -108,6 +108,35 @@
   height: 100%;
 }
 
+.slide-markdown-scaling {
+  justify-content: safe center;
+}
+
+.slide-markdown-scaling .slide-markdown-scaling__content {
+  --mdf-slide-line-height: 1.875;
+  --text-sm-font-size: calc(var(--mdf-slide-font-size) * 0.875);
+  --text-sm-line-height: calc(var(--mdf-slide-font-size) * 1.25);
+  --text-xs-font-size: calc(var(--mdf-slide-font-size) * 0.875);
+  --text-xs-line-height: var(--mdf-slide-font-size);
+}
+
+.slide-markdown-scaling__content {
+  flex: 0 0 auto;
+  min-height: 0;
+  gap: var(--mdf-slide-font-size, 16px);
+}
+
+.slide-markdown-scaling__content--contents {
+  display: contents;
+}
+
+.slide-markdown-scaling__content:not(.slide-markdown-scaling__content--contents)
+  .content-render-iframe-sandbox--markdown {
+  height: auto;
+  min-height: 0;
+  overflow: visible;
+}
+
 .slide-player-wrapper {
   pointer-events: none;
   position: absolute;

--- a/src/components/Slide/slide.css
+++ b/src/components/Slide/slide.css
@@ -108,7 +108,7 @@
   height: 100%;
 }
 
-.slide-markdown-scaling {
+.slide-markdown-scaling[data-markdown-slide-scaling="fit"] {
   justify-content: safe center;
 }
 

--- a/src/components/Slide/utils/markdownScaling.test.ts
+++ b/src/components/Slide/utils/markdownScaling.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import type { Element } from "../types";
+import { resolveMarkdownScalingMode } from "./markdownScaling";
+
+const element = (
+  type: Element["type"],
+  isRenderable: boolean | undefined = true
+): Element => ({
+  content: "content",
+  type,
+  is_renderable: isRenderable,
+});
+
+describe("resolveMarkdownScalingMode", () => {
+  it("fully fits accumulated Markdown-rendered elements as one page", () => {
+    expect(
+      resolveMarkdownScalingMode([
+        element("title"),
+        element("text"),
+        element("code"),
+      ])
+    ).toBe("fit");
+  });
+
+  it("applies only the viewport base size to mixed HTML or slot pages", () => {
+    expect(
+      resolveMarkdownScalingMode([element("title"), element("html")])
+    ).toBe("base");
+    expect(resolveMarkdownScalingMode([element("slot"), element("text")])).toBe(
+      "base"
+    );
+  });
+
+  it("allows hidden HTML pre-rendering beside visible Markdown", () => {
+    expect(
+      resolveMarkdownScalingMode([
+        element("html", false),
+        element("text", true),
+      ])
+    ).toBe("fit");
+  });
+
+  it("does not activate without visible Markdown content", () => {
+    expect(resolveMarkdownScalingMode([])).toBe("disabled");
+    expect(resolveMarkdownScalingMode([element("text", false)])).toBe(
+      "disabled"
+    );
+    expect(resolveMarkdownScalingMode([element("html")])).toBe("disabled");
+    expect(resolveMarkdownScalingMode([element("slot")])).toBe("disabled");
+  });
+});

--- a/src/components/Slide/utils/markdownScaling.ts
+++ b/src/components/Slide/utils/markdownScaling.ts
@@ -1,0 +1,27 @@
+import type { Element } from "../types";
+
+const isMarkdownRenderedElement = (element: Element) =>
+  element.type !== "html" && element.type !== "slot";
+
+export type MarkdownScalingMode = "base" | "disabled" | "fit";
+
+/**
+ * Fully fits Markdown-only pages. Mixed pages still receive the viewport base
+ * font-size while retaining their existing HTML/slot layout and scroll model.
+ */
+export const resolveMarkdownScalingMode = (
+  elementList: Element[]
+): MarkdownScalingMode => {
+  const visibleElements = elementList.filter(
+    (element) => element.is_renderable !== false
+  );
+  const markdownElementCount = visibleElements.filter(
+    isMarkdownRenderedElement
+  ).length;
+
+  if (markdownElementCount === 0) {
+    return "disabled";
+  }
+
+  return markdownElementCount === visibleElements.length ? "fit" : "base";
+};


### PR DESCRIPTION
## Summary

- add shared presentation-scaling primitives used by HTML iframe and Markdown slides
- fit pure Markdown pages as one logical slide while applying the viewport base size to mixed HTML/Markdown pages
- scale Markdown typography, code, and interaction controls together, with Storybook and unit-test coverage
- restore Tailwind Play utilities for preloaded HTML sandboxes when they become visible, including hidden content updates
- deduplicate Markdown fit passes, cancel stale mode-transition frames, and preserve top alignment for mixed pages
- reinitialize sandbox internals when a keyed slide changes content type, mode, or effective scaling lifecycle
- add focused full-viewport Storybook cases for code-only, H1-only, Mermaid-only, and math-only Markdown slides

## Why

Markdown slides already filled the Slide viewport, but retained fixed 16px article typography. HTML slides used viewport-driven sizing and overflow compression, so fullscreen Markdown looked undersized on large screens or scrolled instead of behaving like a presentation.

Preloaded HTML sandboxes can initialize under `display: none`. Tailwind Play then emits only its preflight styles and misses arbitrary utilities until its runtime is explicitly rescanned after the sandbox becomes visible.

## User impact

Markdown slides now expand on large screens, compress dense content, and recalculate after resize or dynamic content updates. Standalone ContentRender keeps its existing 16px/30px defaults, and consumers can opt out with `enableMarkdownScaling={false}`.

Repeated observer notifications with unchanged dimensions no longer rerun the iterative fitter. Disabling or changing scaling mode cancels queued work, and mixed Markdown/HTML or Markdown/slot pages retain their previous top-aligned layout.

HTML slides keep their gradients, spacing, colors, grids, and typography when users navigate to a preloaded page. Sandboxes are rescanned only after hidden content changes, avoiding unnecessary recompilation on ordinary back-and-forth navigation.

The same keyed slide element can switch between Markdown and HTML without leaving an empty iframe or stale React root. Lifecycle changes remount only the private sandbox instance, while ordinary HTML content updates retain the existing iframe.

## Validation

- `pnpm exec vitest run --project unit` — 30 files, 160 tests
- `npm test`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck:exports`
- `npm run build`
- `npm run build-storybook`
- real Chromium Storybook verification at 1280×720 and 1920×1080 for dense, sparse, accumulated, disabled, and dynamic-content Markdown scenarios
- real Chromium verification of the original `CustomPlayerActionButton` sequence 116: 1280×719 iframe, restored 28.76px padding, gradient backgrounds, 43.14px title, styled table header, and zero console errors
- real Chromium verification of `DynamicMarkdownToHtmlSandbox`: Markdown → HTML → Markdown → HTML on one slide key, styled Tailwind target, and zero console errors
- real Chromium 1280×720 verification of the four focused Markdown stories: 10.86px fitted code base, 39.36px H1, 1216px Mermaid SVG, 23.62px KaTeX, and zero console errors or warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown-only slides now scale to fit the presentation viewport, with an option to enable/disable the behavior.
  * Presentation-based sizing is applied across Markdown typography, code blocks, form controls, and embedded iframe sandbox content.
  * Responsive code block UI sizing (font + copy icon) now follows the presentation typography scale.
* **Bug Fixes**
  * Improved iframe sandbox refresh, resize/mutation handling, and cleanup to keep Tailwind rendering accurate when visibility changes.
* **Tests**
  * Added unit and Storybook coverage for presentation sizing, overflow/compression behavior, Markdown scaling modes, and Tailwind runtime refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
