### PR TITLE
chore: release markdown-flow-ui 0.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-flow-ui",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-flow-ui",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
       ]
     }
   },
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary

- publish `markdown-flow-ui@0.2.2` to npm with the `latest` dist-tag
- merge the workflow-generated version bump back into `main`

## Verification

- GitHub Actions publish run completed successfully
- build and npm publish steps passed
- workflow log confirms `+ markdown-flow-ui@0.2.2`

Publish run: https://github.com/ai-shifu/markdown-flow-ui/actions/runs/29157466793

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the package version to 0.2.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->