### PR TITLE
chore: make commit titles clear to product users

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,9 @@ rules, but must not duplicate or redefine them.
   below.
 - Subject: use English Conventional Commits without scope parentheses, such as
   `type: summary`; do not use `type(scope): summary`. Use a lowercase type and
-  imperative mood.
+  imperative mood. Write the summary in plain language that product users can
+  understand. When a change affects users, describe the user-visible outcome
+  or benefit instead of only naming the internal implementation detail.
 - Body: include exactly two sections, `Changed:` and `Benefit:`.
 - Classification: use `chore` for repository-maintenance-only instruction or
   generated guidance updates like this file.


### PR DESCRIPTION
## Summary

- Require commit summaries to use plain language that product users can understand.
- For user-impacting changes, describe the visible outcome or benefit instead of only internal implementation details.

## Why

Commit history should communicate the purpose of a change to product users and reviewers, not only to the implementation author.

## Validation

- `npm run format`
- `npm run lint` (passes with existing warnings)
- `npm test`
- Vite production build and Tailwind CSS build