### PR TITLE
chore: release markdown-flow-ui 0.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-flow-ui",
-  "version": "0.2.2",
+  "version": "0.2.3-dev.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-flow-ui",
-      "version": "0.2.2",
+      "version": "0.2.3-dev.3",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-flow-ui",
-  "version": "0.2.3-dev.3",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-flow-ui",
-      "version": "0.2.3-dev.3",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
       ]
     }
   },
-  "version": "0.2.3-dev.3",
+  "version": "0.2.3",
   "type": "module",
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
       ]
     }
   },
-  "version": "0.2.2",
+  "version": "0.2.3-dev.3",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary

- Release markdown-flow-ui@0.2.3 from the current main branch.
- Includes the merged UI fixes and slide/player behavior updates after 0.2.2.

## Verification

- Publish (manual) release workflow succeeded.
- npm latest now resolves to markdown-flow-ui@0.2.3.

## Included after 0.2.2

- #187 fix: open sandbox-rendered links in a new tab
- #190 fix: sync interaction overlay visibility with player controls
- #191 feat: extend silent image slide auto-advance delay
- #192 fix: allow reselecting history interactions
- #195 chore: make commit titles clear to product users
