### PR TITLE
chore: clean vite declaration diagnostics

### DIFF
--- a/src/components/ContentRender/CodeBlock.tsx
+++ b/src/components/ContentRender/CodeBlock.tsx
@@ -7,7 +7,7 @@ import { Copy, Check } from "lucide-react";
  */
 export interface CodeBlockProps {
   /** The code content and nested elements to render.*/
-  children: React.ReactNode;
+  children?: React.ReactNode;
   /** Optional CSS class name for the pre element. */
   className?: string;
   /** Text to display on the copy button (i18n support). */

--- a/src/components/ContentRender/ContentRender.tsx
+++ b/src/components/ContentRender/ContentRender.tsx
@@ -9,6 +9,7 @@ import remarkBreaks from "remark-breaks";
 import remarkFlow from "remark-flow";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
+import type { PluggableList } from "unified";
 import { CustomRenderBarProps, OnSendContentParams } from "../types";
 import { sanitizeInvalidTagName } from "./utils/sanitize-invalid-tag-name";
 import { stripSvgTextLineBreaks } from "./utils/strip-svg-text-line-breaks";
@@ -236,9 +237,14 @@ type CustomComponents = ComponentsWithCustomVariable & {
   }>;
 };
 
-const remarkPlugins = [remarkGfm, remarkMath, remarkFlow, remarkBreaks];
+const remarkPlugins: PluggableList = [
+  remarkGfm,
+  remarkMath,
+  remarkFlow,
+  remarkBreaks,
+];
 
-const rehypePlugins = [
+const rehypePlugins: PluggableList = [
   preserveCustomVariableProperties,
   rehypeRaw,
   sanitizeInvalidTagName,

--- a/src/components/MarkdownFlowEditor/MarkdownFlowEditor.stories.tsx
+++ b/src/components/MarkdownFlowEditor/MarkdownFlowEditor.stories.tsx
@@ -17,7 +17,7 @@ const meta = {
   },
   tags: ["autodocs"],
   argTypes: {
-    value: {
+    content: {
       control: "text",
       description: "Markdown content to edit",
     },
@@ -25,23 +25,13 @@ const meta = {
       action: "onChange",
       description: "Callback when content changes",
     },
-    className: {
-      control: "text",
-      description: "Class name to apply to the editor",
-    },
-    readOnly: {
-      control: "boolean",
-      description: "Whether the editor is read-only",
-    },
     disabled: {
       control: "boolean",
       description: "Disables user interactions and editing",
     },
   },
   args: {
-    value: "",
-    className: "",
-    readOnly: false,
+    content: "",
     disabled: false,
   },
 } satisfies Meta<typeof MarkdownFlowEditor>;

--- a/src/components/Slide/diff-utils.ts
+++ b/src/components/Slide/diff-utils.ts
@@ -35,9 +35,8 @@ export const splitDiffContent = (content?: string): DiffContentParts => {
   }
 
   const patchText = matched[1]?.trim();
-  const trailingContent = content
-    .slice(matched.index + matched[0].length)
-    .trim();
+  const matchStart = matched.index ?? 0;
+  const trailingContent = content.slice(matchStart + matched[0].length).trim();
 
   return {
     patchText: patchText || undefined,

--- a/src/components/Slide/types.ts
+++ b/src/components/Slide/types.ts
@@ -48,6 +48,7 @@ export interface Element {
   readonly?: boolean;
   audio_segments?: ElementAudioSegment[];
   subtitle_cues?: ElementSubtitleCue[];
+  [key: string]: unknown;
 }
 
 export interface SlidePlayerCustomActionContext {

--- a/src/components/ui/inputGroup/input-group.tsx
+++ b/src/components/ui/inputGroup/input-group.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
+import type { TextAreaProps, TextAreaRef } from "rc-textarea";
 
 import { cn } from "../../../lib/utils";
 import { Button } from "./button";
@@ -139,22 +140,21 @@ function InputGroupInput({
   );
 }
 
-const InputGroupTextarea = React.forwardRef<
-  HTMLTextAreaElement,
-  React.ComponentProps<"textarea">
->(({ className, ...props }, ref) => {
-  return (
-    <Textarea
-      ref={ref}
-      data-slot="input-group-control"
-      className={cn(
-        "resize-none rounded-none border-0 bg-transparent py-1.5 shadow-none dark:bg-transparent",
-        className
-      )}
-      {...props}
-    />
-  );
-});
+const InputGroupTextarea = React.forwardRef<TextAreaRef, TextAreaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <Textarea
+        ref={ref}
+        data-slot="input-group-control"
+        className={cn(
+          "resize-none rounded-none border-0 bg-transparent py-1.5 shadow-none dark:bg-transparent",
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
 InputGroupTextarea.displayName = "InputGroupTextarea";
 
 export {

--- a/src/components/ui/inputGroup/textarea.tsx
+++ b/src/components/ui/inputGroup/textarea.tsx
@@ -1,12 +1,15 @@
 import * as React from "react";
 
-import RcTextArea, { TextAreaProps as RcTextAreaProps } from "rc-textarea";
+import RcTextArea, {
+  TextAreaProps as RcTextAreaProps,
+  TextAreaRef,
+} from "rc-textarea";
 
 import { cn } from "../../../lib/utils";
 
 type TextareaProps = RcTextAreaProps;
 
-const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+const Textarea = React.forwardRef<TextAreaRef, TextareaProps>(
   ({ className, autoSize = { minRows: 1 }, style, ...props }, ref) => {
     return (
       <RcTextArea

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,6 +9,7 @@ export default defineConfig({
     dts({
       insertTypesEntry: true,
       entryRoot: "src",
+      tsconfigPath: "tsconfig.build.json",
     }),
   ],
 


### PR DESCRIPTION
## Summary

- Typed the markdown plugin arrays as `PluggableList` so `react-markdown` declaration generation accepts the plugin lists.
- Made `CodeBlock` children optional to match React Markdown's `pre` renderer props.
- Aligned `MarkdownFlowEditor` stories with the real `content` prop and removed non-existent story controls.
- Guarded `matched.index` in slide diff parsing.
- Allowed slide elements to carry backend/story metadata fields beyond the normalized render fields.
- Updated the rc-textarea wrapper ref type to `TextAreaRef`.
- Pointed `vite-plugin-dts` at `tsconfig.build.json` so declaration generation does not emit config/test declarations outside the package entry root.

## Why

The library build previously succeeded but printed declaration-generation diagnostics from implementation and story type drift. This PR keeps the build output clean and makes future dts regressions easier to spot.

## Validation

- `npm run build` — exits 0 with no `error TS` diagnostics and no `Outside emitted` dts warnings.
- `npm run typecheck:exports`
- `npm run lint`
- `git diff --check`
