### PR TITLE
feat: keep lesson interactions movable

### DIFF
--- a/src/components/Slide/Slide.tsx
+++ b/src/components/Slide/Slide.tsx
@@ -3,11 +3,12 @@ import React, {
   useCallback,
   useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
 } from "react";
-import { ChevronLeft } from "lucide-react";
+import { ChevronLeft, GripHorizontal } from "lucide-react";
 
 import { isSandboxInteractionMessage } from "../../lib/sandboxInteraction";
 import { cn } from "../../lib/utils";
@@ -45,8 +46,11 @@ import {
   type MobileViewMode,
 } from "./utils/mobileScreenMode";
 import {
+  clampInteractionOverlayDragOffset,
   shouldPresentInteractionOverlay,
   shouldRenderInteractionOverlay,
+  type InteractionOverlayDragBounds,
+  type InteractionOverlayDragOffset,
 } from "./utils/interactionPlayback";
 import { resolveMarkdownScalingMode } from "./utils/markdownScaling";
 import { shouldWakePlayerControlsAfterNavigation } from "./utils/playerNavigationContext";
@@ -95,6 +99,13 @@ const DEFAULT_INTERACTION_OVERLAY_OPEN_DELAY_MS = 300;
 const DEFAULT_INTERACTION_OVERLAY_FALLBACK_OFFSET_PX = 160;
 const DEFAULT_INTERACTION_SUBTITLE_GAP_PX = 16;
 const DEFAULT_RESOLVED_INTERACTION_AUTO_CLOSE_DELAY_MS = 3000;
+const DEFAULT_INTERACTION_OVERLAY_DRAG_OFFSET: InteractionOverlayDragOffset = {
+  x: 0,
+  y: 0,
+};
+type InteractionOverlayLayoutRect = Pick<DOMRect, "left" | "top">;
+const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
 const INTERACTION_ACTIVITY_SELECTOR = [
   "button",
   "input",
@@ -167,6 +178,10 @@ interface InteractionOverlayCardProps {
   copyButtonText?: string;
   copiedButtonText?: string;
   onSend?: (content: OnSendContentParams) => void;
+  onDragHandlePointerCancel?: React.PointerEventHandler<HTMLButtonElement>;
+  onDragHandlePointerDown?: React.PointerEventHandler<HTMLButtonElement>;
+  onDragHandlePointerMove?: React.PointerEventHandler<HTMLButtonElement>;
+  onDragHandlePointerUp?: React.PointerEventHandler<HTMLButtonElement>;
   readonly?: boolean;
 }
 
@@ -196,9 +211,24 @@ const InteractionOverlayCard = memo(
     copyButtonText,
     copiedButtonText,
     onSend,
+    onDragHandlePointerCancel,
+    onDragHandlePointerDown,
+    onDragHandlePointerMove,
+    onDragHandlePointerUp,
     readonly = false,
   }: InteractionOverlayCardProps) => (
     <div className="slide-player__interaction-card">
+      <button
+        type="button"
+        className="slide-player__interaction-drag-handle"
+        aria-label="Move interaction"
+        onPointerCancel={onDragHandlePointerCancel}
+        onPointerDown={onDragHandlePointerDown}
+        onPointerMove={onDragHandlePointerMove}
+        onPointerUp={onDragHandlePointerUp}
+      >
+        <GripHorizontal aria-hidden="true" />
+      </button>
       <div className="slide-player__interaction-header">
         <p className="slide-player__interaction-title">{title}</p>
       </div>
@@ -242,18 +272,7 @@ const isInteractionActivityTarget = (
   target: EventTarget | null
 ): target is HTMLElement =>
   target instanceof HTMLElement &&
-  target.matches(INTERACTION_ACTIVITY_SELECTOR);
-const TEXT_ENTRY_SELECTOR = [
-  'input:not([type="button"]):not([type="checkbox"]):not([type="radio"]):not([type="submit"])',
-  "textarea",
-  '[contenteditable=""]',
-  '[contenteditable="true"]',
-  '[contenteditable="plaintext-only"]',
-].join(", ");
-
-const isTextEntryTarget = (target: EventTarget | null): target is HTMLElement =>
-  target instanceof HTMLElement && target.matches(TEXT_ENTRY_SELECTOR);
-
+  Boolean(target.closest(INTERACTION_ACTIVITY_SELECTOR));
 export interface SlideProps extends React.ComponentProps<"section"> {
   elementList?: Element[];
   /** Locale used for built-in UI text when a more specific text prop is not provided. */
@@ -368,6 +387,15 @@ const Slide: React.FC<SlideProps> = ({
   const interactionAutoCloseTimerRef = useRef<number | null>(null);
   const interactionOverlayOpenTimerRef = useRef<number | null>(null);
   const interactionOverlayRef = useRef<HTMLDivElement | null>(null);
+  const interactionOverlayLayoutRectRef =
+    useRef<InteractionOverlayLayoutRect | null>(null);
+  const interactionOverlayDragRef = useRef<{
+    pointerId: number;
+    startClientX: number;
+    startClientY: number;
+    startOffset: InteractionOverlayDragOffset;
+    bounds: InteractionOverlayDragBounds;
+  } | null>(null);
   const prevRenderElementKeysRef = useRef<string[]>([]);
   const shouldScrollToBottomRef = useRef(false);
   const pendingInteractionOverlayStepIndexRef = useRef<number | null>(null);
@@ -470,7 +498,11 @@ const Slide: React.FC<SlideProps> = ({
     useState(false);
   const [hasInteractionOverlayActivity, setHasInteractionOverlayActivity] =
     useState(false);
-  const [hasFocusedInteractionTextInput, setHasFocusedInteractionTextInput] =
+  const [interactionOverlayDragOffset, setInteractionOverlayDragOffset] =
+    useState<InteractionOverlayDragOffset>(
+      DEFAULT_INTERACTION_OVERLAY_DRAG_OFFSET
+    );
+  const [isInteractionOverlayDragging, setIsInteractionOverlayDragging] =
     useState(false);
   const [
     interactionOverlaySubtitleOffset,
@@ -641,8 +673,14 @@ const Slide: React.FC<SlideProps> = ({
         "--slide-player-mobile-control-count": String(
           playerCustomActionCount + 4
         ),
+        "--slide-interaction-drag-x": `${interactionOverlayDragOffset.x}px`,
+        "--slide-interaction-drag-y": `${interactionOverlayDragOffset.y}px`,
       }) as React.CSSProperties,
-    [playerCustomActionCount]
+    [
+      interactionOverlayDragOffset.x,
+      interactionOverlayDragOffset.y,
+      playerCustomActionCount,
+    ]
   );
   const hasAvailableStepAudio = currentAudioSequenceKeys.length > 0;
   const currentInteractionResetKey = useMemo(() => {
@@ -1516,13 +1554,6 @@ const Slide: React.FC<SlideProps> = ({
   const shouldShowInteractionOverlay = shouldRenderInteractionOverlay({
     hasActiveInteraction: Boolean(activeInteractionElement),
     isInteractionOverlayOpen,
-    shouldBlockPlaybackForInteraction:
-      shouldBlockPlaybackForInteraction &&
-      !isInteractionReadonly &&
-      !hasResolvedInteractionInput,
-    playerControlsVisible,
-    shouldMountPlayer,
-    hasFocusedTextInput: hasFocusedInteractionTextInput,
   });
 
   const handleInteractionSend = useCallback(
@@ -1571,8 +1602,14 @@ const Slide: React.FC<SlideProps> = ({
     }
 
     setHasInteractionOverlayActivity(false);
-    setHasFocusedInteractionTextInput(false);
   }, [activeInteractionElement, isInteractionOverlayOpen]);
+
+  useEffect(() => {
+    setInteractionOverlayDragOffset(DEFAULT_INTERACTION_OVERLAY_DRAG_OFFSET);
+    setIsInteractionOverlayDragging(false);
+    interactionOverlayDragRef.current = null;
+    interactionOverlayLayoutRectRef.current = null;
+  }, [activeInteractionElement]);
 
   useEffect(() => {
     if (!shouldShowInteractionOverlay) {
@@ -2026,9 +2063,7 @@ const Slide: React.FC<SlideProps> = ({
 
   const stopOverlayPropagation = useCallback(
     (
-      event:
-        | React.PointerEvent<HTMLDivElement>
-        | React.MouseEvent<HTMLDivElement>
+      event: React.PointerEvent<HTMLElement> | React.MouseEvent<HTMLElement>
     ) => {
       event.stopPropagation();
 
@@ -2038,6 +2073,179 @@ const Slide: React.FC<SlideProps> = ({
       }
     },
     [playerControlsVisible, revealPlayerControls]
+  );
+
+  const getInteractionOverlayDragBounds = useCallback(
+    (
+      overlayElement: HTMLElement,
+      startOffset: InteractionOverlayDragOffset
+    ): InteractionOverlayDragBounds | null => {
+      const viewportElement = viewportRef.current;
+
+      if (!viewportElement) {
+        return null;
+      }
+
+      const overlayRect = overlayElement.getBoundingClientRect();
+      const viewportRect = viewportElement.getBoundingClientRect();
+
+      return {
+        minX: startOffset.x + viewportRect.left - overlayRect.left,
+        maxX: startOffset.x + viewportRect.right - overlayRect.right,
+        minY: startOffset.y + viewportRect.top - overlayRect.top,
+        maxY: startOffset.y + viewportRect.bottom - overlayRect.bottom,
+      };
+    },
+    []
+  );
+
+  useIsomorphicLayoutEffect(() => {
+    const overlayElement = interactionOverlayRef.current;
+
+    if (!shouldShowInteractionOverlay || !overlayElement) {
+      interactionOverlayLayoutRectRef.current = null;
+      return;
+    }
+
+    const previousRect = interactionOverlayLayoutRectRef.current;
+    const currentRect = overlayElement.getBoundingClientRect();
+
+    if (!previousRect || isInteractionOverlayDragging) {
+      interactionOverlayLayoutRectRef.current = currentRect;
+      return;
+    }
+
+    const nextOffset = {
+      x: interactionOverlayDragOffset.x + previousRect.left - currentRect.left,
+      y: interactionOverlayDragOffset.y + previousRect.top - currentRect.top,
+    };
+    const bounds = getInteractionOverlayDragBounds(
+      overlayElement,
+      interactionOverlayDragOffset
+    );
+    const clampedOffset = bounds
+      ? clampInteractionOverlayDragOffset(nextOffset, bounds)
+      : nextOffset;
+
+    interactionOverlayLayoutRectRef.current = {
+      left: currentRect.left + clampedOffset.x - interactionOverlayDragOffset.x,
+      top: currentRect.top + clampedOffset.y - interactionOverlayDragOffset.y,
+    };
+
+    if (
+      clampedOffset.x !== interactionOverlayDragOffset.x ||
+      clampedOffset.y !== interactionOverlayDragOffset.y
+    ) {
+      setInteractionOverlayDragOffset(clampedOffset);
+    }
+  }, [
+    getInteractionOverlayDragBounds,
+    interactionOverlayDragOffset,
+    isInteractionOverlayDragging,
+    playerControlsVisible,
+    shouldMountPlayer,
+    shouldShowInteractionOverlay,
+  ]);
+
+  const handleInteractionOverlayPointerDown = useCallback(
+    (event: React.PointerEvent<HTMLElement>) => {
+      stopOverlayPropagation(event);
+
+      if (
+        event.button !== 0 ||
+        !event.currentTarget.isConnected ||
+        !interactionOverlayRef.current
+      ) {
+        return;
+      }
+
+      const bounds = getInteractionOverlayDragBounds(
+        interactionOverlayRef.current,
+        interactionOverlayDragOffset
+      );
+
+      if (!bounds) {
+        return;
+      }
+
+      event.preventDefault();
+      event.currentTarget.setPointerCapture(event.pointerId);
+      interactionOverlayDragRef.current = {
+        pointerId: event.pointerId,
+        startClientX: event.clientX,
+        startClientY: event.clientY,
+        startOffset: interactionOverlayDragOffset,
+        bounds,
+      };
+      setIsInteractionOverlayDragging(true);
+    },
+    [
+      getInteractionOverlayDragBounds,
+      interactionOverlayDragOffset,
+      stopOverlayPropagation,
+    ]
+  );
+
+  const handleInteractionOverlaySurfacePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (isMobileDevice) {
+        stopOverlayPropagation(event);
+        return;
+      }
+
+      if (isInteractionActivityTarget(event.target)) {
+        stopOverlayPropagation(event);
+        return;
+      }
+
+      handleInteractionOverlayPointerDown(event);
+    },
+    [
+      handleInteractionOverlayPointerDown,
+      isMobileDevice,
+      stopOverlayPropagation,
+    ]
+  );
+
+  const handleInteractionOverlayPointerMove = useCallback(
+    (event: React.PointerEvent<HTMLElement>) => {
+      const dragState = interactionOverlayDragRef.current;
+
+      if (!dragState || dragState.pointerId !== event.pointerId) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      setInteractionOverlayDragOffset(
+        clampInteractionOverlayDragOffset(
+          {
+            x: dragState.startOffset.x + event.clientX - dragState.startClientX,
+            y: dragState.startOffset.y + event.clientY - dragState.startClientY,
+          },
+          dragState.bounds
+        )
+      );
+    },
+    []
+  );
+
+  const endInteractionOverlayDrag = useCallback(
+    (event: React.PointerEvent<HTMLElement>) => {
+      const dragState = interactionOverlayDragRef.current;
+
+      if (!dragState || dragState.pointerId !== event.pointerId) {
+        return;
+      }
+
+      event.stopPropagation();
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+      interactionOverlayDragRef.current = null;
+      setIsInteractionOverlayDragging(false);
+    },
+    []
   );
 
   const handleSurfacePointerDown = useCallback(
@@ -2249,39 +2457,25 @@ const Slide: React.FC<SlideProps> = ({
               "slide-interaction-overlay",
               playerControlsVisible && shouldMountPlayer
                 ? "slide-interaction-overlay--with-player"
-                : "slide-interaction-overlay--standalone"
+                : "slide-interaction-overlay--standalone",
+              !isMobileDevice && "slide-interaction-overlay--draggable",
+              isInteractionOverlayDragging &&
+                "slide-interaction-overlay--dragging"
             )}
             onClick={stopOverlayPropagation}
-            onPointerDown={stopOverlayPropagation}
+            onPointerDown={handleInteractionOverlaySurfacePointerDown}
             onPointerDownCapture={(event) => {
               if (isInteractionActivityTarget(event.target)) {
                 setHasInteractionOverlayActivity(true);
               }
             }}
+            onPointerMove={handleInteractionOverlayPointerMove}
+            onPointerUp={endInteractionOverlayDrag}
+            onPointerCancel={endInteractionOverlayDrag}
             onFocusCapture={(event) => {
-              if (isTextEntryTarget(event.target)) {
-                setHasFocusedInteractionTextInput(true);
-              }
-
               if (isInteractionActivityTarget(event.target)) {
                 setHasInteractionOverlayActivity(true);
               }
-            }}
-            onBlurCapture={(event) => {
-              if (!isTextEntryTarget(event.target)) {
-                return;
-              }
-
-              const nextFocusTarget = event.relatedTarget;
-
-              if (
-                nextFocusTarget instanceof HTMLElement &&
-                interactionOverlayRef.current?.contains(nextFocusTarget)
-              ) {
-                return;
-              }
-
-              setHasFocusedInteractionTextInput(false);
             }}
             onInputCapture={(event) => {
               if (isInteractionActivityTarget(event.target)) {
@@ -2309,6 +2503,10 @@ const Slide: React.FC<SlideProps> = ({
                 localeTexts.interactionTexts.copiedButtonText
               }
               onSend={handleInteractionSend}
+              onDragHandlePointerCancel={endInteractionOverlayDrag}
+              onDragHandlePointerDown={handleInteractionOverlayPointerDown}
+              onDragHandlePointerMove={handleInteractionOverlayPointerMove}
+              onDragHandlePointerUp={endInteractionOverlayDrag}
               readonly={isInteractionReadonly}
               title={
                 interactionTexts?.title ??

--- a/src/components/Slide/player.css
+++ b/src/components/Slide/player.css
@@ -246,8 +246,41 @@
     0 4px 6px -4px rgba(0, 0, 0, 0.1);
 }
 
+.slide-player__interaction-drag-handle {
+  position: absolute;
+  top: 12px;
+  right: 14px;
+  z-index: 1;
+  display: inline-flex;
+  width: 32px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  border-radius: 9999px;
+  background: transparent;
+  color: color-mix(in srgb, var(--foreground) 42%, transparent);
+  cursor: grab;
+  touch-action: none;
+}
+
+.slide-player__interaction-drag-handle:hover {
+  color: color-mix(in srgb, var(--foreground) 68%, transparent);
+}
+
+.slide-player__interaction-drag-handle:active {
+  cursor: grabbing;
+}
+
+.slide-player__interaction-drag-handle svg {
+  width: 18px;
+  height: 18px;
+  stroke-width: 2;
+}
+
 .slide-player__interaction-header {
-  padding: 24px 24px 0;
+  padding: 24px 56px 0 24px;
 }
 
 .slide-player__interaction-title {
@@ -346,7 +379,22 @@
   left: 50%;
   z-index: 4;
   width: min(760px, calc(var(--slide-mobile-viewport-width, 100dvw) - 48px));
-  transform: translateX(-50%);
+  transform: translate(
+    calc(-50% + var(--slide-interaction-drag-x, 0px)),
+    var(--slide-interaction-drag-y, 0px)
+  );
+  transition: opacity 160ms ease;
+}
+
+.slide-interaction-overlay--draggable {
+  cursor: grab;
+}
+
+.slide-interaction-overlay--dragging {
+  cursor: grabbing;
+  opacity: 0.36;
+  transition: none;
+  user-select: none;
 }
 
 .slide-interaction-overlay--with-player {
@@ -375,7 +423,10 @@
 
 .slide--mobile-device .slide-interaction-overlay {
   --slide-player-bottom-offset: 0px;
-  transform: none;
+  transform: translate(
+    var(--slide-interaction-drag-x, 0px),
+    var(--slide-interaction-drag-y, 0px)
+  );
   left: 12px;
   right: 12px;
   width: auto;

--- a/src/components/Slide/utils/interactionPlayback.test.ts
+++ b/src/components/Slide/utils/interactionPlayback.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  clampInteractionOverlayDragOffset,
   shouldPresentInteractionOverlay,
   shouldRenderInteractionOverlay,
 } from "./interactionPlayback";
@@ -60,54 +61,11 @@ describe("shouldPresentInteractionOverlay", () => {
 });
 
 describe("shouldRenderInteractionOverlay", () => {
-  it("hides unresolved blocking interactions when player controls auto-hide", () => {
+  it("renders active open interactions", () => {
     expect(
       shouldRenderInteractionOverlay({
         hasActiveInteraction: true,
         isInteractionOverlayOpen: true,
-        shouldBlockPlaybackForInteraction: true,
-        playerControlsVisible: false,
-        shouldMountPlayer: true,
-        hasFocusedTextInput: false,
-      })
-    ).toBe(false);
-  });
-
-  it("shows unresolved blocking interactions while player controls are visible", () => {
-    expect(
-      shouldRenderInteractionOverlay({
-        hasActiveInteraction: true,
-        isInteractionOverlayOpen: true,
-        shouldBlockPlaybackForInteraction: true,
-        playerControlsVisible: true,
-        shouldMountPlayer: true,
-        hasFocusedTextInput: false,
-      })
-    ).toBe(true);
-  });
-
-  it("keeps resolved or readonly interactions visible even when player controls hide", () => {
-    expect(
-      shouldRenderInteractionOverlay({
-        hasActiveInteraction: true,
-        isInteractionOverlayOpen: true,
-        shouldBlockPlaybackForInteraction: false,
-        playerControlsVisible: false,
-        shouldMountPlayer: true,
-        hasFocusedTextInput: false,
-      })
-    ).toBe(true);
-  });
-
-  it("does not hide the overlay when the player is not mounted", () => {
-    expect(
-      shouldRenderInteractionOverlay({
-        hasActiveInteraction: true,
-        isInteractionOverlayOpen: true,
-        shouldBlockPlaybackForInteraction: true,
-        playerControlsVisible: false,
-        shouldMountPlayer: false,
-        hasFocusedTextInput: false,
       })
     ).toBe(true);
   });
@@ -117,10 +75,6 @@ describe("shouldRenderInteractionOverlay", () => {
       shouldRenderInteractionOverlay({
         hasActiveInteraction: false,
         isInteractionOverlayOpen: true,
-        shouldBlockPlaybackForInteraction: true,
-        playerControlsVisible: true,
-        shouldMountPlayer: true,
-        hasFocusedTextInput: false,
       })
     ).toBe(false);
   });
@@ -130,24 +84,27 @@ describe("shouldRenderInteractionOverlay", () => {
       shouldRenderInteractionOverlay({
         hasActiveInteraction: true,
         isInteractionOverlayOpen: false,
-        shouldBlockPlaybackForInteraction: true,
-        playerControlsVisible: true,
-        shouldMountPlayer: true,
-        hasFocusedTextInput: false,
       })
     ).toBe(false);
   });
+});
 
-  it("keeps blocking interactions visible while a text input is focused", () => {
+describe("clampInteractionOverlayDragOffset", () => {
+  it("keeps dragged interaction overlays within the viewport bounds", () => {
     expect(
-      shouldRenderInteractionOverlay({
-        hasActiveInteraction: true,
-        isInteractionOverlayOpen: true,
-        shouldBlockPlaybackForInteraction: true,
-        playerControlsVisible: false,
-        shouldMountPlayer: true,
-        hasFocusedTextInput: true,
-      })
-    ).toBe(true);
+      clampInteractionOverlayDragOffset(
+        { x: 240, y: -180 },
+        { minX: -80, maxX: 120, minY: -100, maxY: 60 }
+      )
+    ).toEqual({ x: 120, y: -100 });
+  });
+
+  it("preserves offsets that are already inside the viewport bounds", () => {
+    expect(
+      clampInteractionOverlayDragOffset(
+        { x: 24, y: -12 },
+        { minX: -80, maxX: 120, minY: -100, maxY: 60 }
+      )
+    ).toEqual({ x: 24, y: -12 });
   });
 });

--- a/src/components/Slide/utils/interactionPlayback.ts
+++ b/src/components/Slide/utils/interactionPlayback.ts
@@ -46,35 +46,38 @@ export const shouldPresentInteractionOverlay = ({
 export interface ShouldRenderInteractionOverlayParams {
   hasActiveInteraction: boolean;
   isInteractionOverlayOpen: boolean;
-  shouldBlockPlaybackForInteraction: boolean;
-  playerControlsVisible: boolean;
-  shouldMountPlayer: boolean;
-  hasFocusedTextInput: boolean;
 }
 
 export const shouldRenderInteractionOverlay = ({
   hasActiveInteraction,
   isInteractionOverlayOpen,
-  shouldBlockPlaybackForInteraction,
-  playerControlsVisible,
-  shouldMountPlayer,
-  hasFocusedTextInput,
 }: ShouldRenderInteractionOverlayParams) => {
   if (!hasActiveInteraction || !isInteractionOverlayOpen) {
     return false;
   }
 
-  if (hasFocusedTextInput) {
-    return true;
-  }
-
-  if (
-    shouldBlockPlaybackForInteraction &&
-    shouldMountPlayer &&
-    !playerControlsVisible
-  ) {
-    return false;
-  }
-
   return true;
 };
+
+export interface InteractionOverlayDragOffset {
+  x: number;
+  y: number;
+}
+
+export interface InteractionOverlayDragBounds {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+}
+
+const clampNumber = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+export const clampInteractionOverlayDragOffset = (
+  offset: InteractionOverlayDragOffset,
+  bounds: InteractionOverlayDragBounds
+): InteractionOverlayDragOffset => ({
+  x: clampNumber(offset.x, bounds.minX, bounds.maxX),
+  y: clampNumber(offset.y, bounds.minY, bounds.maxY),
+});


### PR DESCRIPTION
## What changed

- Keeps unresolved lesson interaction overlays visible instead of hiding them with auto-hidden player controls.
- Adds bounded drag support for interaction overlays inside the slide viewport.
- Uses full-card dragging on desktop while preserving normal clicks on answer buttons and inputs.
- Adds a lightweight drag handle for mobile so touch dragging does not conflict with answering or page gestures.
- Preserves answered/history interaction behavior: history interactions can still briefly re-open, allow reselection, then auto-continue and stay hidden if the learner does not act.

## Why

Unanswered interaction blocks are required for the learning flow, but they can cover lesson content. Learners need a way to keep the interaction visible while moving it out of the way.

## Validation

- `npx vitest run src/components/Slide/utils/interactionPlayback.test.ts`
- `npm run lint`
- `npm run typecheck:exports`
- `npm run build` succeeded; existing vite-plugin-dts diagnostics are still printed and are unrelated to this change.
- Installed the packed local tarball into `ai-shifu/src/cook-web` for manual learner-flow testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added draggable interaction overlays for slide players.
  * Added a dedicated drag handle with visual hover and active states.
  * Overlay movement is constrained to remain within the visible slide area.
  * Dragging works consistently on mobile devices.

* **Bug Fixes**
  * Improved interaction overlay positioning and behavior while dragging.
  * Simplified overlay visibility behavior for active and open interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->