### PR TITLE
fix: restore clickable interaction cards

### DIFF
--- a/src/components/Slide/Slide.stories.tsx
+++ b/src/components/Slide/Slide.stories.tsx
@@ -2580,7 +2580,7 @@ export const DesktopInteractionOverlayPointerDrag: Story = {
     docs: {
       description: {
         story:
-          "Exercises desktop overlay dragging through pointer events so the full interaction card remains movable within the slide viewport.",
+          "Exercises desktop overlay dragging from the header handle and verifies the interaction body no longer starts a drag.",
       },
     },
   },
@@ -2592,25 +2592,35 @@ export const DesktopInteractionOverlayPointerDrag: Story = {
   play: async ({ canvasElement }) => {
     const overlay = await waitFor(() => {
       const element = canvasElement.querySelector(
-        ".slide-interaction-overlay--draggable"
+        ".slide-interaction-overlay"
       ) as HTMLElement | null;
 
       expect(element).not.toBeNull();
       return element as HTMLElement;
     });
-    const capturedPointerIds = installPointerCaptureSpy(overlay);
+    const handle = overlay.querySelector(
+      '[aria-label="Move interaction"]'
+    ) as HTMLElement | null;
+    const body = overlay.querySelector(
+      ".slide-player__interaction-body"
+    ) as HTMLElement | null;
+
+    expect(handle).not.toBeNull();
+    expect(body).not.toBeNull();
+
+    const capturedPointerIds = installPointerCaptureSpy(handle as HTMLElement);
     const beforeOffsets = getOverlayDragOffsets(overlay);
-    const overlayRect = overlay.getBoundingClientRect();
+    const handleRect = (handle as HTMLElement).getBoundingClientRect();
 
     triggerPointerDrag(
-      overlay,
+      handle as HTMLElement,
       {
-        clientX: overlayRect.left + 48,
-        clientY: overlayRect.top + 40,
+        clientX: handleRect.left + handleRect.width / 2,
+        clientY: handleRect.top + handleRect.height / 2,
       },
       {
-        clientX: overlayRect.left + 128,
-        clientY: overlayRect.top + 84,
+        clientX: handleRect.left + handleRect.width / 2 + 80,
+        clientY: handleRect.top + handleRect.height / 2 + 44,
       }
     );
 
@@ -2620,6 +2630,25 @@ export const DesktopInteractionOverlayPointerDrag: Story = {
       expect(
         overlay.classList.contains("slide-interaction-overlay--dragging")
       ).toBe(false);
+    });
+
+    const afterHandleOffsets = getOverlayDragOffsets(overlay);
+    const bodyRect = (body as HTMLElement).getBoundingClientRect();
+
+    triggerPointerDrag(
+      body as HTMLElement,
+      {
+        clientX: bodyRect.left + 48,
+        clientY: bodyRect.top + 48,
+      },
+      {
+        clientX: bodyRect.left + 108,
+        clientY: bodyRect.top + 104,
+      }
+    );
+
+    await waitFor(() => {
+      expect(getOverlayDragOffsets(overlay)).toEqual(afterHandleOffsets);
     });
   },
 };

--- a/src/components/Slide/Slide.tsx
+++ b/src/components/Slide/Slide.tsx
@@ -227,7 +227,9 @@ const InteractionOverlayCard = memo(
         onPointerMove={onDragHandlePointerMove}
         onPointerUp={onDragHandlePointerUp}
       >
-        <GripHorizontal aria-hidden="true" />
+        <span className="slide-player__interaction-drag-handle-icon">
+          <GripHorizontal aria-hidden="true" />
+        </span>
       </button>
       <div className="slide-player__interaction-header">
         <p className="slide-player__interaction-title">{title}</p>
@@ -2186,27 +2188,6 @@ const Slide: React.FC<SlideProps> = ({
     ]
   );
 
-  const handleInteractionOverlaySurfacePointerDown = useCallback(
-    (event: React.PointerEvent<HTMLDivElement>) => {
-      if (isMobileDevice) {
-        stopOverlayPropagation(event);
-        return;
-      }
-
-      if (isInteractionActivityTarget(event.target)) {
-        stopOverlayPropagation(event);
-        return;
-      }
-
-      handleInteractionOverlayPointerDown(event);
-    },
-    [
-      handleInteractionOverlayPointerDown,
-      isMobileDevice,
-      stopOverlayPropagation,
-    ]
-  );
-
   const handleInteractionOverlayPointerMove = useCallback(
     (event: React.PointerEvent<HTMLElement>) => {
       const dragState = interactionOverlayDragRef.current;
@@ -2458,20 +2439,15 @@ const Slide: React.FC<SlideProps> = ({
               playerControlsVisible && shouldMountPlayer
                 ? "slide-interaction-overlay--with-player"
                 : "slide-interaction-overlay--standalone",
-              !isMobileDevice && "slide-interaction-overlay--draggable",
               isInteractionOverlayDragging &&
                 "slide-interaction-overlay--dragging"
             )}
             onClick={stopOverlayPropagation}
-            onPointerDown={handleInteractionOverlaySurfacePointerDown}
             onPointerDownCapture={(event) => {
               if (isInteractionActivityTarget(event.target)) {
                 setHasInteractionOverlayActivity(true);
               }
             }}
-            onPointerMove={handleInteractionOverlayPointerMove}
-            onPointerUp={endInteractionOverlayDrag}
-            onPointerCancel={endInteractionOverlayDrag}
             onFocusCapture={(event) => {
               if (isInteractionActivityTarget(event.target)) {
                 setHasInteractionOverlayActivity(true);

--- a/src/components/Slide/player.css
+++ b/src/components/Slide/player.css
@@ -249,10 +249,11 @@
 .slide-player__interaction-drag-handle {
   position: absolute;
   top: 10px;
-  left: 50%;
+  right: 0;
+  left: 0;
   z-index: 1;
-  display: inline-flex;
-  width: 40px;
+  display: flex;
+  width: 100%;
   height: 32px;
   align-items: center;
   justify-content: center;
@@ -263,13 +264,12 @@
   color: color-mix(in srgb, var(--foreground) 46%, transparent);
   cursor: grab;
   touch-action: none;
-  transform: translateX(-50%);
 }
 
 .slide-player__interaction-drag-handle-icon {
   display: inline-flex;
-  width: 100%;
-  height: 100%;
+  width: 40px;
+  height: 32px;
   align-items: center;
   justify-content: center;
   border-radius: 9999px;

--- a/src/components/Slide/player.css
+++ b/src/components/Slide/player.css
@@ -248,21 +248,31 @@
 
 .slide-player__interaction-drag-handle {
   position: absolute;
-  top: 12px;
-  right: 14px;
+  top: 10px;
+  left: 50%;
   z-index: 1;
   display: inline-flex;
-  width: 32px;
-  height: 28px;
+  width: 40px;
+  height: 32px;
   align-items: center;
   justify-content: center;
   padding: 0;
   border: 0;
   border-radius: 9999px;
   background: transparent;
-  color: color-mix(in srgb, var(--foreground) 42%, transparent);
+  color: color-mix(in srgb, var(--foreground) 46%, transparent);
   cursor: grab;
   touch-action: none;
+  transform: translateX(-50%);
+}
+
+.slide-player__interaction-drag-handle-icon {
+  display: inline-flex;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
 }
 
 .slide-player__interaction-drag-handle:hover {
@@ -386,12 +396,7 @@
   transition: opacity 160ms ease;
 }
 
-.slide-interaction-overlay--draggable {
-  cursor: grab;
-}
-
 .slide-interaction-overlay--dragging {
-  cursor: grabbing;
   opacity: 0.36;
   transition: none;
   user-select: none;


### PR DESCRIPTION
Changed:
- limited interaction overlay dragging to the dedicated handle instead of the full card surface
- moved the drag handle to the top-center of the interaction card and kept the icon centered inside the handle
- updated Slide pointer-drag story coverage so dragging the body no longer moves the overlay while desktop and mobile handle dragging still work

Benefit:
- learners can click interaction choices again without accidental drags blocking the card content
- the drag affordance is clearer and easier to find because it sits at the visual center of the card header


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Desktop interaction overlays can now be dragged only from the designated header handle.
  * Dragging from the interaction body no longer unintentionally moves the overlay.

* **Style**
  * Updated the drag handle’s position, dimensions, icon presentation, and colors for improved visibility and usability.
  * Removed misleading drag cursor states from the overlay surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->