### PR TITLE
chore: release markdown-flow-ui  0.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-flow-ui",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-flow-ui",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
       ]
     }
   },
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## What
- bump `markdown-flow-ui` to `0.2.5`
- include the interaction overlay drag-area fix already merged into `main`
- record the published release version back into `package.json` and `package-lock.json`

## Verification
- GitHub Actions `Publish (manual)` succeeded on `release/0.2.5`
- npm package published: `markdown-flow-ui@0.2.5`
- workflow run: https://github.com/ai-shifu/markdown-flow-ui/actions/runs/29908974954