### PR TITLE
feat: make interaction drag handles easier to spot

### DIFF
--- a/src/components/Slide/Slide.tsx
+++ b/src/components/Slide/Slide.tsx
@@ -229,6 +229,8 @@ const InteractionOverlayCard = memo(
       >
         <span className="slide-player__interaction-drag-handle-icon">
           <GripHorizontal aria-hidden="true" />
+          <GripHorizontal aria-hidden="true" />
+          <GripHorizontal aria-hidden="true" />
         </span>
       </button>
       <div className="slide-player__interaction-header">

--- a/src/components/Slide/player.css
+++ b/src/components/Slide/player.css
@@ -268,7 +268,7 @@
 
 .slide-player__interaction-drag-handle-icon {
   display: inline-flex;
-  width: 40px;
+  width: 52px;
   height: 32px;
   align-items: center;
   justify-content: center;
@@ -284,9 +284,14 @@
 }
 
 .slide-player__interaction-drag-handle svg {
+  flex: 0 0 auto;
   width: 18px;
   height: 18px;
   stroke-width: 2;
+}
+
+.slide-player__interaction-drag-handle svg + svg {
+  margin-left: -2px;
 }
 
 .slide-player__interaction-header {


### PR DESCRIPTION
## Summary

- Extend the interaction overlay drag indicator from one to three `GripHorizontal` icons.
- Keep each icon at its existing size and overlap adjacent SVG margins so the dot density stays visually consistent.
- Preserve the existing drag hit area and pointer behavior.

## User impact

The interaction card now has a longer, easier-to-find drag indicator without changing how dragging works.

## Validation

- `npm run format`
- `npm run lint` (passes with 18 existing warnings)
- `npm test` (repository currently reports no tests specified)
- `npm run build` (completes successfully; the existing `rc-input` TS2742 declaration diagnostics are still printed)
- Storybook visual verification with the desktop interaction-overlay drag story