### PR TITLE
fix: keep input actions aligned in wide containers

### DIFF
--- a/src/components/ContentRender/MarkdownFlowInput.stories.tsx
+++ b/src/components/ContentRender/MarkdownFlowInput.stories.tsx
@@ -88,6 +88,9 @@ export const WideContainer: Story = {
     />
   ),
   play: async ({ canvasElement }) => {
+    const wrapper = canvasElement.querySelector(
+      ".custom-variable-container"
+    ) as HTMLElement | null;
     const group = canvasElement.querySelector(
       "[data-slot='input-group']"
     ) as HTMLElement | null;
@@ -98,19 +101,26 @@ export const WideContainer: Story = {
       "button[data-size='icon-sm']"
     ) as HTMLElement | null;
 
+    expect(wrapper).not.toBeNull();
     expect(group).not.toBeNull();
     expect(control).not.toBeNull();
     expect(button).not.toBeNull();
 
+    const wrapperRect = (wrapper as HTMLElement).getBoundingClientRect();
     const groupRect = (group as HTMLElement).getBoundingClientRect();
     const controlRect = (control as HTMLElement).getBoundingClientRect();
     const buttonRect = (button as HTMLElement).getBoundingClientRect();
+    const controlButtonGap = buttonRect.left - controlRect.right;
+    const buttonRightGap = groupRect.right - buttonRect.right;
 
-    expect(groupRect.width).toBeGreaterThanOrEqual(740);
-    expect(controlRect.width).toBeGreaterThan(500);
-    expect(controlRect.right).toBeLessThanOrEqual(buttonRect.left);
-    expect(groupRect.right - buttonRect.right).toBeGreaterThanOrEqual(0);
-    expect(groupRect.right - buttonRect.right).toBeLessThan(16);
+    expect(Math.abs(groupRect.width - wrapperRect.width)).toBeLessThanOrEqual(
+      1
+    );
+    expect(controlRect.width).toBeGreaterThan(0);
+    expect(controlButtonGap).toBeGreaterThanOrEqual(0);
+    expect(controlButtonGap).toBeLessThan(16);
+    expect(buttonRightGap).toBeGreaterThanOrEqual(0);
+    expect(buttonRightGap).toBeLessThan(16);
   },
 };
 

--- a/src/components/ContentRender/MarkdownFlowInput.stories.tsx
+++ b/src/components/ContentRender/MarkdownFlowInput.stories.tsx
@@ -1,7 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import React from "react";
+import { expect } from "storybook/test";
 
 import MarkdownFlowInput from "./MarkdownFlowInput";
+import "./contentRender.css";
 
 const meta = {
   title: "MarkdownFlow/MarkdownFlowInput",
@@ -37,16 +39,21 @@ type InteractiveMarkdownFlowInputProps = React.ComponentProps<
   typeof MarkdownFlowInput
 > & {
   initialValue: string;
+  width?: React.CSSProperties["width"];
 };
 
 const InteractiveMarkdownFlowInput = ({
   initialValue,
+  width = 420,
   ...args
 }: InteractiveMarkdownFlowInputProps) => {
   const [value, setValue] = React.useState(initialValue);
 
   return (
-    <div style={{ width: 420 }}>
+    <div
+      className="custom-variable-container"
+      style={{ width, maxWidth: "100%" }}
+    >
       <MarkdownFlowInput
         {...args}
         value={value}
@@ -64,6 +71,47 @@ export const Default: Story = {
   render: (args) => (
     <InteractiveMarkdownFlowInput {...args} initialValue="Hello Shifu" />
   ),
+};
+
+export const WideContainer: Story = {
+  args: {
+    className: "w-full max-w-none",
+  },
+  parameters: {
+    layout: "padded",
+  },
+  render: (args) => (
+    <InteractiveMarkdownFlowInput
+      {...args}
+      initialValue="The input fills the available width"
+      width={750}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const group = canvasElement.querySelector(
+      "[data-slot='input-group']"
+    ) as HTMLElement | null;
+    const control = canvasElement.querySelector(
+      "[data-slot='input-group-control']"
+    ) as HTMLElement | null;
+    const button = canvasElement.querySelector(
+      "button[data-size='icon-sm']"
+    ) as HTMLElement | null;
+
+    expect(group).not.toBeNull();
+    expect(control).not.toBeNull();
+    expect(button).not.toBeNull();
+
+    const groupRect = (group as HTMLElement).getBoundingClientRect();
+    const controlRect = (control as HTMLElement).getBoundingClientRect();
+    const buttonRect = (button as HTMLElement).getBoundingClientRect();
+
+    expect(groupRect.width).toBeGreaterThanOrEqual(740);
+    expect(controlRect.width).toBeGreaterThan(500);
+    expect(controlRect.right).toBeLessThanOrEqual(buttonRect.left);
+    expect(groupRect.right - buttonRect.right).toBeGreaterThanOrEqual(0);
+    expect(groupRect.right - buttonRect.right).toBeLessThan(16);
+  },
 };
 
 export const Disabled: Story = {

--- a/src/components/ContentRender/contentRender.css
+++ b/src/components/ContentRender/contentRender.css
@@ -321,7 +321,6 @@
 }
 .custom-variable-container .rc-textarea {
   width: 100%;
-  max-width: 500px;
 }
 .custom-variable-container textarea {
   color: #0a0a0a;

--- a/src/components/ui/inputGroup/input-group.tsx
+++ b/src/components/ui/inputGroup/input-group.tsx
@@ -76,7 +76,7 @@ function InputGroupAddon({
 }
 
 const inputGroupButtonVariants = cva(
-  "text-sm shadow-none flex gap-2 items-center",
+  "text-sm shadow-none flex shrink-0 gap-2 items-center",
   {
     variants: {
       size: {
@@ -132,7 +132,7 @@ function InputGroupInput({
     <Input
       data-slot="input-group-control"
       className={cn(
-        "rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0 dark:bg-transparent",
+        "min-w-0 flex-1 rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0 dark:bg-transparent",
         className
       )}
       {...props}
@@ -147,7 +147,7 @@ const InputGroupTextarea = React.forwardRef<TextAreaRef, TextAreaProps>(
         ref={ref}
         data-slot="input-group-control"
         className={cn(
-          "resize-none rounded-none border-0 bg-transparent py-1.5 shadow-none dark:bg-transparent",
+          "min-w-0 max-w-none flex-1 resize-none rounded-none border-0 bg-transparent py-1.5 shadow-none dark:bg-transparent",
           className
         )}
         {...props}


### PR DESCRIPTION
## Summary

- Let text inputs and textareas fill the available InputGroup width.
- Keep action buttons from shrinking when the container grows or narrows.
- Remove the textarea-level 500px cap while preserving the existing outer-container default width.
- Add a responsive Storybook regression scenario with wrapper-relative and control-spacing assertions.

## Root cause

The custom textarea imposed its own 500px maximum width inside the InputGroup. When a consumer widened the outer interaction container, the control stopped growing and the submit button remained beside that capped control instead of staying at the right edge.

## Impact

Wide interaction forms now keep the submit button aligned to the right without relying on consumer-specific positioning. Existing default-width forms keep their current dimensions. The regression story also remains valid when Storybook uses a narrow canvas.

## Validation

- `npm run format`
- `npm run lint` (passes with existing repository warnings)
- `npm run typecheck:exports`
- `npm test` (repository currently reports no tests specified)
- `npm run build`
- `npm run build-storybook`
- Manual Storybook geometry checks at 1280×720 and 390×844, with no browser console errors

The focused Storybook Vitest run could not start locally because the matching Playwright Chromium binary is unavailable; the story compiles successfully and was verified in a headed browser.