### PR TITLE
chore: release markdown-flow-ui 0.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-flow-ui",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-flow-ui",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
       ]
     }
   },
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
Changed:
- Published markdown-flow-ui 0.2.6 to the npm latest dist-tag through the manual release workflow.
- Updated package.json and package-lock.json to the published stable version.
- Verified the GitHub Actions build and publish job succeeded and npm latest resolves to 0.2.6.

Benefit:
- Consumers can install the latest stable release with the recent interaction drag-handle and wide-container input alignment improvements.