### PR TITLE
fix: keep mobile slide inputs focused during keyboard resize

### DIFF
--- a/src/components/ContentRender/ContentRender.stories.tsx
+++ b/src/components/ContentRender/ContentRender.stories.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, userEvent, waitFor } from "storybook/test";
 
 import runStreamFixtureText from "../../../测试数据.json?raw";
 import ContentRender, {
@@ -32,6 +33,74 @@ const meta = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
+
+const CONTENT_RENDER_INPUT_CHURN_CONTENT =
+  "?[%{{content_render_input_churn}}...Type your answer]";
+
+const ContentRenderInputPropChurnPreview = () => {
+  const [renderCount, setRenderCount] = useState(0);
+
+  return (
+    <div>
+      <button
+        type="button"
+        data-testid="rerender-content-render"
+        onClick={() => setRenderCount((count) => count + 1)}
+      >
+        Rerender
+      </button>
+      <ContentRender
+        content={CONTENT_RENDER_INPUT_CHURN_CONTENT}
+        defaultSelectedValues={["Existing choice"]}
+        beforeSend={() => true}
+        onSend={() => undefined}
+        sandboxLoadingText={`Render ${renderCount}`}
+      />
+    </div>
+  );
+};
+
+export const InputKeepsFocusDuringPropChurn: Story = {
+  args: {},
+  parameters: {
+    layout: "centered",
+  },
+  render: () => <ContentRenderInputPropChurnPreview />,
+  play: async ({ canvasElement }) => {
+    const textarea = await waitFor(() => {
+      const element = canvasElement.querySelector(
+        "textarea"
+      ) as HTMLTextAreaElement | null;
+
+      expect(element).not.toBeNull();
+      return element as HTMLTextAreaElement;
+    });
+    const typedValue = "Input survives prop churn";
+    const rerenderButton = canvasElement.querySelector(
+      '[data-testid="rerender-content-render"]'
+    ) as HTMLButtonElement | null;
+
+    expect(rerenderButton).not.toBeNull();
+
+    await userEvent.click(textarea);
+    await userEvent.type(textarea, typedValue);
+
+    expect(document.activeElement).toBe(textarea);
+    expect(textarea.value).toBe(typedValue);
+
+    rerenderButton?.click();
+
+    await waitFor(() => {
+      const currentTextarea = canvasElement.querySelector(
+        "textarea"
+      ) as HTMLTextAreaElement | null;
+
+      expect(currentTextarea).toBe(textarea);
+      expect(document.activeElement).toBe(textarea);
+      expect(currentTextarea?.value).toBe(typedValue);
+    });
+  },
+};
 
 // ==============================================================================
 // Markdown Test Content Constants

--- a/src/components/ContentRender/ContentRender.tsx
+++ b/src/components/ContentRender/ContentRender.tsx
@@ -481,103 +481,119 @@ const ContentRender: React.FC<ContentRenderProps> = ({
     ? defaultSelectedValues
     : interactionDefaults.selectedValues || fallbackSelectedValues;
 
-  const components: CustomComponents = {
-    "custom-button-after-content": ({
-      children,
-    }: {
-      children: React.ReactNode;
-    }) => {
-      return (
-        <button
-          className="content-render-custom-button-after-content"
-          onClick={onClickCustomButtonAfterContent}
-        >
-          <span className="content-render-custom-button-after-content-inner">
-            {children}
-          </span>
-        </button>
-      );
-    },
-    "custom-variable": (props) => (
-      <CustomButtonInputVariable
-        {...props}
-        readonly={readonly}
-        defaultButtonText={resolvedDefaultButtonText}
-        defaultInputText={resolvedDefaultInputText}
-        defaultSelectedValues={resolvedDefaultSelectedValues}
-        onSend={onSend}
-        beforeSend={beforeSend}
-        locale={locale}
-        confirmButtonText={resolvedConfirmButtonText}
-        // tooltipMinLength={tooltipMinLength}
-      />
-    ),
-    code: (props) => {
-      const { className, children, ...rest } = props as {
-        className?: string;
-        children?: React.ReactNode;
-      };
-      const match = /language-(\w+)/.exec(className || "");
-      const language = match?.[1];
-      if (language === "mermaid") {
-        const chartContent = children?.toString().replace(/\n$/, "") || "";
-        const frozen = mermaidBlockIsComplete(renderContent, chartContent);
-        return <MermaidChart chart={chartContent} frozen={frozen} />;
-      }
-
-      return (
-        <code className={className} {...rest}>
-          {children}
-        </code>
-      );
-    },
-    table: ({ ...props }) => (
-      <div className="content-render-table-container">
-        <table className="content-render-table" {...props} />
-      </div>
-    ),
-    th: ({ ...props }) => <th className="content-render-th" {...props} />,
-    td: ({ ...props }) => <td className="content-render-td" {...props} />,
-    tr: ({ ...props }) => <tr className="content-render-tr" {...props} />,
-    li: ({ node, ...props }) => {
-      const className = node?.properties?.className;
-      const hasTaskListItem =
-        (typeof className === "string" &&
-          className.includes("task-list-item")) ||
-        (Array.isArray(className) && className.includes("task-list-item"));
-      if (hasTaskListItem) {
-        return <li className="content-render-task-list-item" {...props} />;
-      }
-      return <li {...props} />;
-    },
-    ol: ({ ...props }) => <ol className="content-render-ol" {...props} />,
-    ul: ({ ...props }) => <ul className="content-render-ul" {...props} />,
-    input: ({ ...props }) => {
-      if (props.type === "checkbox") {
+  const components = useMemo<CustomComponents>(
+    () => ({
+      "custom-button-after-content": ({
+        children,
+      }: {
+        children: React.ReactNode;
+      }) => {
         return (
-          <input
-            type="checkbox"
-            className="content-render-checkbox"
-            disabled
-            {...props}
-          />
+          <button
+            className="content-render-custom-button-after-content"
+            onClick={onClickCustomButtonAfterContent}
+          >
+            <span className="content-render-custom-button-after-content-inner">
+              {children}
+            </span>
+          </button>
         );
-      }
-      return <input {...props} />;
-    },
-    a: ({ children, ...props }) => (
-      <a target="_blank" rel="noopener noreferrer" {...props}>
-        {children}
-      </a>
-    ),
-    pre: (props) => (
-      <CodeBlock
-        {...props}
-        copyButtonText={resolvedCopyButtonText}
-        copiedButtonText={resolvedCopiedButtonText}
-      />
-    ),
-  };
+      },
+      "custom-variable": (props) => (
+        <CustomButtonInputVariable
+          {...props}
+          readonly={readonly}
+          defaultButtonText={resolvedDefaultButtonText}
+          defaultInputText={resolvedDefaultInputText}
+          defaultSelectedValues={resolvedDefaultSelectedValues}
+          onSend={onSend}
+          beforeSend={beforeSend}
+          locale={locale}
+          confirmButtonText={resolvedConfirmButtonText}
+          // tooltipMinLength={tooltipMinLength}
+        />
+      ),
+      code: (props) => {
+        const { className, children, ...rest } = props as {
+          className?: string;
+          children?: React.ReactNode;
+        };
+        const match = /language-(\w+)/.exec(className || "");
+        const language = match?.[1];
+        if (language === "mermaid") {
+          const chartContent = children?.toString().replace(/\n$/, "") || "";
+          const frozen = mermaidBlockIsComplete(renderContent, chartContent);
+          return <MermaidChart chart={chartContent} frozen={frozen} />;
+        }
+
+        return (
+          <code className={className} {...rest}>
+            {children}
+          </code>
+        );
+      },
+      table: ({ ...props }) => (
+        <div className="content-render-table-container">
+          <table className="content-render-table" {...props} />
+        </div>
+      ),
+      th: ({ ...props }) => <th className="content-render-th" {...props} />,
+      td: ({ ...props }) => <td className="content-render-td" {...props} />,
+      tr: ({ ...props }) => <tr className="content-render-tr" {...props} />,
+      li: ({ node, ...props }) => {
+        const className = node?.properties?.className;
+        const hasTaskListItem =
+          (typeof className === "string" &&
+            className.includes("task-list-item")) ||
+          (Array.isArray(className) && className.includes("task-list-item"));
+        if (hasTaskListItem) {
+          return <li className="content-render-task-list-item" {...props} />;
+        }
+        return <li {...props} />;
+      },
+      ol: ({ ...props }) => <ol className="content-render-ol" {...props} />,
+      ul: ({ ...props }) => <ul className="content-render-ul" {...props} />,
+      input: ({ ...props }) => {
+        if (props.type === "checkbox") {
+          return (
+            <input
+              type="checkbox"
+              className="content-render-checkbox"
+              disabled
+              {...props}
+            />
+          );
+        }
+        return <input {...props} />;
+      },
+      a: ({ children, ...props }) => (
+        <a target="_blank" rel="noopener noreferrer" {...props}>
+          {children}
+        </a>
+      ),
+      pre: (props) => (
+        <CodeBlock
+          {...props}
+          copyButtonText={resolvedCopyButtonText}
+          copiedButtonText={resolvedCopiedButtonText}
+        />
+      ),
+    }),
+    [
+      beforeSend,
+      locale,
+      onClickCustomButtonAfterContent,
+      onSend,
+      readonly,
+      renderContent,
+      resolvedConfirmButtonText,
+      resolvedCopiedButtonText,
+      resolvedCopyButtonText,
+      resolvedDefaultButtonText,
+      resolvedDefaultInputText,
+      resolvedDefaultSelectedValues,
+    ]
+  );
 
   const hasPotentialSandboxTags = useMemo(
     () => SANDBOX_TAG_HINT_PATTERN.test(renderContent),

--- a/src/components/ContentRender/ContentRender.tsx
+++ b/src/components/ContentRender/ContentRender.tsx
@@ -237,6 +237,21 @@ type CustomComponents = ComponentsWithCustomVariable & {
   }>;
 };
 
+type MarkdownComponentRuntimeValues = {
+  beforeSend?: (param: OnSendContentParams) => boolean;
+  locale?: MarkdownFlowLocale;
+  onClickCustomButtonAfterContent?: () => void;
+  onSend?: (content: OnSendContentParams) => void;
+  readonly: boolean;
+  renderContent: string;
+  resolvedConfirmButtonText: string;
+  resolvedCopiedButtonText: string;
+  resolvedCopyButtonText: string;
+  resolvedDefaultButtonText?: string;
+  resolvedDefaultInputText?: string;
+  resolvedDefaultSelectedValues?: string[];
+};
+
 const remarkPlugins: PluggableList = [
   remarkGfm,
   remarkMath,
@@ -301,6 +316,26 @@ const splitTextByCharacterChunk = (value: string, chunkSize: number) => {
     chunk: characters.slice(0, safeChunkSize).join(""),
     rest: characters.slice(safeChunkSize).join(""),
   };
+};
+
+const areStringArraysEqual = (left?: string[], right?: string[]) => {
+  if (left === right) {
+    return true;
+  }
+  if (!left || !right || left.length !== right.length) {
+    return false;
+  }
+  return left.every((value, index) => value === right[index]);
+};
+
+const useStableStringArray = (values?: string[]) => {
+  const valuesRef = useRef<string[] | undefined>(values);
+
+  if (!areStringArraysEqual(valuesRef.current, values)) {
+    valuesRef.current = values;
+  }
+
+  return valuesRef.current;
 };
 
 const ContentRender: React.FC<ContentRenderProps> = ({
@@ -480,6 +515,38 @@ const ContentRender: React.FC<ContentRenderProps> = ({
   const resolvedDefaultSelectedValues = defaultSelectedValues?.length
     ? defaultSelectedValues
     : interactionDefaults.selectedValues || fallbackSelectedValues;
+  const stableDefaultSelectedValues = useStableStringArray(
+    resolvedDefaultSelectedValues
+  );
+  const componentRuntimeValuesRef = useRef<MarkdownComponentRuntimeValues>({
+    beforeSend,
+    locale,
+    onClickCustomButtonAfterContent,
+    onSend,
+    readonly,
+    renderContent,
+    resolvedConfirmButtonText,
+    resolvedCopiedButtonText,
+    resolvedCopyButtonText,
+    resolvedDefaultButtonText,
+    resolvedDefaultInputText,
+    resolvedDefaultSelectedValues: stableDefaultSelectedValues,
+  });
+
+  componentRuntimeValuesRef.current = {
+    beforeSend,
+    locale,
+    onClickCustomButtonAfterContent,
+    onSend,
+    readonly,
+    renderContent,
+    resolvedConfirmButtonText,
+    resolvedCopiedButtonText,
+    resolvedCopyButtonText,
+    resolvedDefaultButtonText,
+    resolvedDefaultInputText,
+    resolvedDefaultSelectedValues: stableDefaultSelectedValues,
+  };
 
   const components = useMemo<CustomComponents>(
     () => ({
@@ -491,7 +558,9 @@ const ContentRender: React.FC<ContentRenderProps> = ({
         return (
           <button
             className="content-render-custom-button-after-content"
-            onClick={onClickCustomButtonAfterContent}
+            onClick={
+              componentRuntimeValuesRef.current.onClickCustomButtonAfterContent
+            }
           >
             <span className="content-render-custom-button-after-content-inner">
               {children}
@@ -502,14 +571,22 @@ const ContentRender: React.FC<ContentRenderProps> = ({
       "custom-variable": (props) => (
         <CustomButtonInputVariable
           {...props}
-          readonly={readonly}
-          defaultButtonText={resolvedDefaultButtonText}
-          defaultInputText={resolvedDefaultInputText}
-          defaultSelectedValues={resolvedDefaultSelectedValues}
-          onSend={onSend}
-          beforeSend={beforeSend}
-          locale={locale}
-          confirmButtonText={resolvedConfirmButtonText}
+          readonly={componentRuntimeValuesRef.current.readonly}
+          defaultButtonText={
+            componentRuntimeValuesRef.current.resolvedDefaultButtonText
+          }
+          defaultInputText={
+            componentRuntimeValuesRef.current.resolvedDefaultInputText
+          }
+          defaultSelectedValues={
+            componentRuntimeValuesRef.current.resolvedDefaultSelectedValues
+          }
+          onSend={componentRuntimeValuesRef.current.onSend}
+          beforeSend={componentRuntimeValuesRef.current.beforeSend}
+          locale={componentRuntimeValuesRef.current.locale}
+          confirmButtonText={
+            componentRuntimeValuesRef.current.resolvedConfirmButtonText
+          }
           // tooltipMinLength={tooltipMinLength}
         />
       ),
@@ -522,7 +599,10 @@ const ContentRender: React.FC<ContentRenderProps> = ({
         const language = match?.[1];
         if (language === "mermaid") {
           const chartContent = children?.toString().replace(/\n$/, "") || "";
-          const frozen = mermaidBlockIsComplete(renderContent, chartContent);
+          const frozen = mermaidBlockIsComplete(
+            componentRuntimeValuesRef.current.renderContent,
+            chartContent
+          );
           return <MermaidChart chart={chartContent} frozen={frozen} />;
         }
 
@@ -574,25 +654,16 @@ const ContentRender: React.FC<ContentRenderProps> = ({
       pre: (props) => (
         <CodeBlock
           {...props}
-          copyButtonText={resolvedCopyButtonText}
-          copiedButtonText={resolvedCopiedButtonText}
+          copyButtonText={
+            componentRuntimeValuesRef.current.resolvedCopyButtonText
+          }
+          copiedButtonText={
+            componentRuntimeValuesRef.current.resolvedCopiedButtonText
+          }
         />
       ),
     }),
-    [
-      beforeSend,
-      locale,
-      onClickCustomButtonAfterContent,
-      onSend,
-      readonly,
-      renderContent,
-      resolvedConfirmButtonText,
-      resolvedCopiedButtonText,
-      resolvedCopyButtonText,
-      resolvedDefaultButtonText,
-      resolvedDefaultInputText,
-      resolvedDefaultSelectedValues,
-    ]
+    []
   );
 
   const hasPotentialSandboxTags = useMemo(

--- a/src/components/ContentRender/plugins/CustomVariable.tsx
+++ b/src/components/ContentRender/plugins/CustomVariable.tsx
@@ -249,6 +249,13 @@ const CustomButtonInputVariable = ({
   const [selectedValues, setSelectedValues] = React.useState<string[]>(
     defaultSelectedValues || []
   );
+  const interactionDefinitionKey = JSON.stringify({
+    buttonTexts: node.properties?.buttonTexts,
+    buttonValues: node.properties?.buttonValues,
+    isMultiSelect: node.properties?.isMultiSelect,
+    placeholder: node.properties?.placeholder,
+    variableName: node.properties?.variableName,
+  });
   const isMultiSelect = node.properties?.isMultiSelect ?? false;
   const baseButtonTexts = node.properties?.buttonTexts || [];
   const shouldUseFallbackButton =
@@ -354,11 +361,11 @@ const CustomButtonInputVariable = ({
 
   React.useEffect(() => {
     setInputValue(defaultInputText || "");
-  }, [defaultInputText, node]);
+  }, [defaultInputText, interactionDefinitionKey]);
 
   React.useEffect(() => {
     setSelectedValues(defaultSelectedValues || []);
-  }, [defaultSelectedValues, node]);
+  }, [defaultSelectedValues, interactionDefinitionKey]);
 
   return (
     <span className="custom-variable-container inline-flex items-center flex-wrap">

--- a/src/components/Slide/Slide.stories.tsx
+++ b/src/components/Slide/Slide.stories.tsx
@@ -2173,6 +2173,59 @@ const DRAG_TEST_ELEMENT_LIST: Element[] = [
   }),
 ];
 
+const MOBILE_VIEWPORT_INPUT_TEST_ELEMENT_LIST: Element[] = [
+  createExampleElement({
+    sequenceNumber: 1,
+    type: "interaction",
+    content: "?[%{{mobile_resize_input}}...Type your answer]",
+    isNew: true,
+    readonly: false,
+  }),
+];
+
+type TestVisualViewport = EventTarget & {
+  height: number;
+  offsetLeft: number;
+  offsetTop: number;
+  onresize: ((event: Event) => void) | null;
+  onscroll: ((event: Event) => void) | null;
+  pageLeft: number;
+  pageTop: number;
+  scale: number;
+  setSize: (width: number, height: number) => void;
+  width: number;
+};
+
+const createTestVisualViewport = (): TestVisualViewport => {
+  const viewport = Object.assign(new EventTarget(), {
+    height: 844,
+    offsetLeft: 0,
+    offsetTop: 0,
+    onresize: null,
+    onscroll: null,
+    pageLeft: 0,
+    pageTop: 0,
+    scale: 1,
+    width: 390,
+  }) as TestVisualViewport;
+
+  viewport.setSize = (width, height) => {
+    viewport.width = width;
+    viewport.height = height;
+  };
+
+  return viewport;
+};
+
+type PointerTestEventOptions = {
+  button?: number;
+  buttons?: number;
+  clientX: number;
+  clientY: number;
+  pointerId?: number;
+  pointerType?: string;
+};
+
 const dispatchPointerEvent = (
   element: HTMLElement,
   type: string,
@@ -2183,14 +2236,7 @@ const dispatchPointerEvent = (
     clientY,
     pointerId = POINTER_TEST_ID,
     pointerType = "mouse",
-  }: {
-    button?: number;
-    buttons?: number;
-    clientX: number;
-    clientY: number;
-    pointerId?: number;
-    pointerType?: string;
-  }
+  }: PointerTestEventOptions
 ) => {
   element.dispatchEvent(
     new PointerEvent(type, {
@@ -2227,8 +2273,8 @@ const getOverlayDragOffsets = (overlay: HTMLElement) => ({
 
 const triggerPointerDrag = (
   element: HTMLElement,
-  start: { clientX: number; clientY: number },
-  end: { clientX: number; clientY: number }
+  start: PointerTestEventOptions,
+  end: PointerTestEventOptions
 ) => {
   dispatchPointerEvent(element, "pointerdown", start);
   dispatchPointerEvent(element, "pointermove", end);
@@ -2299,6 +2345,85 @@ const MobilePointerDragSlidePreview = ({
   return (
     <div className="mx-auto h-[100dvh] w-[390px] bg-background">
       <Slide className="h-full w-full" {...props} elementList={elementList} />
+    </div>
+  );
+};
+
+const MobileViewportResizeSlidePreview = ({
+  elementList = [],
+  ...props
+}: React.ComponentProps<typeof Slide>) => {
+  const [isReady, setIsReady] = useState(false);
+  const [viewportResizeCount, setViewportResizeCount] = useState(0);
+
+  useEffect(() => {
+    const visualViewport = createTestVisualViewport();
+    const screenOrientation = Object.assign(new EventTarget(), {
+      angle: 0,
+      lock: async () => undefined,
+      onchange: null,
+      type: "portrait-primary",
+      unlock: () => undefined,
+    });
+    const restoreUserAgent = installWindowValueOverride(
+      window.navigator,
+      "userAgent",
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X)"
+    );
+    const restoreVisualViewport = installWindowValueOverride(
+      window,
+      "visualViewport",
+      visualViewport as VisualViewport
+    );
+    const restoreScreenOrientation = installWindowValueOverride(
+      window.screen,
+      "orientation",
+      screenOrientation as ScreenOrientation
+    );
+    const restoreMatchMedia = installWindowValueOverride(
+      window,
+      "matchMedia",
+      ((query: string) => ({
+        matches:
+          query === "(orientation: landscape)" &&
+          visualViewport.width > visualViewport.height,
+        media: query,
+        onchange: null,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        dispatchEvent: () => false,
+      })) as Window["matchMedia"]
+    );
+    const handleViewportResize = () => {
+      setViewportResizeCount((count) => count + 1);
+    };
+
+    visualViewport.addEventListener("resize", handleViewportResize);
+    setIsReady(true);
+
+    return () => {
+      visualViewport.removeEventListener("resize", handleViewportResize);
+      restoreMatchMedia();
+      restoreScreenOrientation();
+      restoreVisualViewport();
+      restoreUserAgent();
+    };
+  }, []);
+
+  if (!isReady) {
+    return null;
+  }
+
+  return (
+    <div className="mx-auto h-[100dvh] w-[390px] bg-background">
+      <Slide
+        className="h-full w-full"
+        {...props}
+        elementList={elementList}
+        interactionTitle={`Interaction ${viewportResizeCount}`}
+      />
     </div>
   );
 };
@@ -2703,6 +2828,58 @@ export const MobileInteractionOverlayPointerDrag: Story = {
     await waitFor(() => {
       expect(capturedPointerIds).toContain(POINTER_TEST_ID);
       expect(getOverlayDragOffsets(overlay)).not.toEqual(beforeOffsets);
+    });
+  },
+};
+
+export const MobileInteractionInputViewportResize: Story = {
+  args: {
+    elementList: MOBILE_VIEWPORT_INPUT_TEST_ELEMENT_LIST,
+    playerControlsVisibility: "visible",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Keeps the mobile interaction textarea mounted, focused, and unchanged when the virtual viewport resizes for the on-screen keyboard.",
+      },
+    },
+  },
+  render: (args) => <MobileViewportResizeSlidePreview {...args} />,
+  play: async ({ canvasElement }) => {
+    const textarea = await waitFor(() => {
+      const element = canvasElement.querySelector(
+        ".slide--mobile-device .slide-interaction-overlay textarea"
+      ) as HTMLTextAreaElement | null;
+
+      expect(element).not.toBeNull();
+      return element as HTMLTextAreaElement;
+    });
+    const typedValue = "Keyboard input stays here";
+
+    await userEvent.click(textarea);
+    await userEvent.type(textarea, typedValue);
+
+    expect(document.activeElement).toBe(textarea);
+    expect(textarea.value).toBe(typedValue);
+
+    const visualViewport =
+      window.visualViewport as unknown as TestVisualViewport;
+    visualViewport.setSize(390, 320);
+    visualViewport.dispatchEvent(new Event("resize"));
+
+    await waitFor(() => {
+      const currentTextarea = canvasElement.querySelector(
+        ".slide--mobile-device .slide-interaction-overlay textarea"
+      ) as HTMLTextAreaElement | null;
+      const interactionTitle = canvasElement.querySelector(
+        ".slide-player__interaction-title"
+      );
+
+      expect(interactionTitle?.textContent).toBe("Interaction 1");
+      expect(currentTextarea).toBe(textarea);
+      expect(document.activeElement).toBe(textarea);
+      expect(currentTextarea?.value).toBe(typedValue);
     });
   },
 };

--- a/src/components/Slide/Slide.stories.tsx
+++ b/src/components/Slide/Slide.stories.tsx
@@ -2212,6 +2212,7 @@ const createTestVisualViewport = (): TestVisualViewport => {
   viewport.setSize = (width, height) => {
     viewport.width = width;
     viewport.height = height;
+    viewport.dispatchEvent(new Event("resize"));
   };
 
   return viewport;
@@ -2365,50 +2366,58 @@ const MobileViewportResizeSlidePreview = ({
       type: "portrait-primary",
       unlock: () => undefined,
     });
-    const restoreUserAgent = installWindowValueOverride(
-      window.navigator,
-      "userAgent",
-      "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X)"
-    );
-    const restoreVisualViewport = installWindowValueOverride(
-      window,
-      "visualViewport",
-      visualViewport as VisualViewport
-    );
-    const restoreScreenOrientation = installWindowValueOverride(
-      window.screen,
-      "orientation",
-      screenOrientation as ScreenOrientation
-    );
-    const restoreMatchMedia = installWindowValueOverride(
-      window,
-      "matchMedia",
-      ((query: string) => ({
-        matches:
-          query === "(orientation: landscape)" &&
-          visualViewport.width > visualViewport.height,
-        media: query,
-        onchange: null,
-        addEventListener: () => undefined,
-        removeEventListener: () => undefined,
-        addListener: () => undefined,
-        removeListener: () => undefined,
-        dispatchEvent: () => false,
-      })) as Window["matchMedia"]
-    );
+    const restorers: Array<() => void> = [];
     const handleViewportResize = () => {
       setViewportResizeCount((count) => count + 1);
     };
 
-    visualViewport.addEventListener("resize", handleViewportResize);
-    setIsReady(true);
+    try {
+      restorers.push(
+        installWindowValueOverride(
+          window.navigator,
+          "userAgent",
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X)"
+        )
+      );
+      restorers.push(
+        installWindowValueOverride(
+          window,
+          "visualViewport",
+          visualViewport as VisualViewport
+        )
+      );
+      restorers.push(
+        installWindowValueOverride(
+          window.screen,
+          "orientation",
+          screenOrientation as ScreenOrientation
+        )
+      );
+      restorers.push(
+        installWindowValueOverride(window, "matchMedia", ((query: string) => ({
+          matches:
+            query === "(orientation: landscape)" &&
+            visualViewport.width > visualViewport.height,
+          media: query,
+          onchange: null,
+          addEventListener: () => undefined,
+          removeEventListener: () => undefined,
+          addListener: () => undefined,
+          removeListener: () => undefined,
+          dispatchEvent: () => false,
+        })) as Window["matchMedia"])
+      );
+
+      visualViewport.addEventListener("resize", handleViewportResize);
+      setIsReady(true);
+    } catch (error) {
+      [...restorers].reverse().forEach((restore) => restore());
+      throw error;
+    }
 
     return () => {
       visualViewport.removeEventListener("resize", handleViewportResize);
-      restoreMatchMedia();
-      restoreScreenOrientation();
-      restoreVisualViewport();
-      restoreUserAgent();
+      [...restorers].reverse().forEach((restore) => restore());
     };
   }, []);
 
@@ -2866,7 +2875,6 @@ export const MobileInteractionInputViewportResize: Story = {
     const visualViewport =
       window.visualViewport as unknown as TestVisualViewport;
     visualViewport.setSize(390, 320);
-    visualViewport.dispatchEvent(new Event("resize"));
 
     await waitFor(() => {
       const currentTextarea = canvasElement.querySelector(

--- a/src/components/Slide/Slide.stories.tsx
+++ b/src/components/Slide/Slide.stories.tsx
@@ -2431,7 +2431,13 @@ const MobileViewportResizeSlidePreview = ({
         className="h-full w-full"
         {...props}
         elementList={elementList}
+        interactionDefaultValueOptions={{
+          resolveDefaultValues: () => ({
+            selectedValues: ["Existing choice"],
+          }),
+        }}
         interactionTitle={`Interaction ${viewportResizeCount}`}
+        onSend={() => undefined}
       />
     </div>
   );

--- a/src/lib/mobileDevice.test.ts
+++ b/src/lib/mobileDevice.test.ts
@@ -41,8 +41,6 @@ describe("resolveMobileViewportLandscape", () => {
       resolveMobileViewportLandscape({
         matchMediaLandscape: true,
         orientationType: "portrait-primary",
-        innerWidth: 390,
-        innerHeight: 844,
       })
     ).toBe(false);
   });
@@ -51,8 +49,6 @@ describe("resolveMobileViewportLandscape", () => {
     expect(
       resolveMobileViewportLandscape({
         orientationType: "landscape-primary",
-        innerWidth: 390,
-        innerHeight: 844,
       })
     ).toBe(true);
   });
@@ -61,8 +57,6 @@ describe("resolveMobileViewportLandscape", () => {
     expect(
       resolveMobileViewportLandscape({
         matchMediaLandscape: true,
-        innerWidth: 390,
-        innerHeight: 844,
       })
     ).toBe(true);
   });
@@ -70,8 +64,6 @@ describe("resolveMobileViewportLandscape", () => {
   it("falls back to stable screen dimensions when orientation metadata is missing", () => {
     expect(
       resolveMobileViewportLandscape({
-        innerWidth: 844,
-        innerHeight: 390,
         screenWidth: 844,
         screenHeight: 390,
       })
@@ -84,17 +76,46 @@ describe("resolveMobileViewportLandscape", () => {
 });
 
 describe("subscribeMobileDeviceChange", () => {
-  it("ignores keyboard-driven viewport resizes", () => {
-    const screenOrientation = new EventTarget();
+  const createMobileWindow = () => {
+    const screenOrientation = Object.assign(new EventTarget(), {
+      type: "portrait-primary",
+    });
     const visualViewport = new EventTarget();
     const win = new EventTarget() as EventTarget & {
+      matchMedia: Window["matchMedia"];
       innerWidth: number;
-      screen: { orientation: EventTarget };
+      screen: {
+        height: number;
+        orientation: EventTarget & { type: string };
+        width: number;
+      };
       visualViewport: EventTarget;
     };
     win.innerWidth = 390;
-    win.screen = { orientation: screenOrientation };
+    win.matchMedia = ((query: string) => ({
+      matches:
+        query === "(orientation: landscape)" &&
+        screenOrientation.type.includes("landscape"),
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    })) as Window["matchMedia"];
+    win.screen = {
+      height: 844,
+      orientation: screenOrientation,
+      width: 390,
+    };
     win.visualViewport = visualViewport;
+
+    return { screenOrientation, visualViewport, win };
+  };
+
+  it("ignores keyboard-driven viewport resizes", () => {
+    const { visualViewport, win } = createMobileWindow();
     let changeCount = 0;
 
     const unsubscribe = subscribeMobileDeviceChange(
@@ -108,23 +129,67 @@ describe("subscribeMobileDeviceChange", () => {
     visualViewport.dispatchEvent(new Event("resize"));
 
     expect(changeCount).toBe(0);
+    unsubscribe();
+  });
+
+  it("ignores same-orientation width changes", () => {
+    const { win } = createMobileWindow();
+    let changeCount = 0;
+
+    const unsubscribe = subscribeMobileDeviceChange(
+      () => {
+        changeCount += 1;
+      },
+      win as unknown as Window
+    );
 
     win.innerWidth = 500;
     win.dispatchEvent(new Event("resize"));
 
-    expect(changeCount).toBe(1);
+    expect(changeCount).toBe(0);
+    unsubscribe();
+  });
+
+  it("notifies once for duplicate events from the same orientation change", () => {
+    const { screenOrientation, win } = createMobileWindow();
+    let changeCount = 0;
+
+    const unsubscribe = subscribeMobileDeviceChange(
+      () => {
+        changeCount += 1;
+      },
+      win as unknown as Window
+    );
+
+    screenOrientation.type = "landscape-primary";
+    win.screen.width = 844;
+    win.screen.height = 390;
 
     win.dispatchEvent(new Event("orientationchange"));
+    win.dispatchEvent(new Event("resize"));
     screenOrientation.dispatchEvent(new Event("change"));
 
-    expect(changeCount).toBe(3);
+    expect(changeCount).toBe(1);
+    unsubscribe();
+  });
+
+  it("stops notifying after unsubscribe", () => {
+    const { screenOrientation, win } = createMobileWindow();
+    let changeCount = 0;
+
+    const unsubscribe = subscribeMobileDeviceChange(
+      () => {
+        changeCount += 1;
+      },
+      win as unknown as Window
+    );
 
     unsubscribe();
-    win.innerWidth = 600;
-    win.dispatchEvent(new Event("resize"));
+
+    screenOrientation.type = "landscape-primary";
     win.dispatchEvent(new Event("orientationchange"));
     screenOrientation.dispatchEvent(new Event("change"));
 
-    expect(changeCount).toBe(3);
+    expect(changeCount).toBe(0);
   });
 });

--- a/src/lib/mobileDevice.test.ts
+++ b/src/lib/mobileDevice.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   resolveMobileDevice,
   resolveMobileViewportLandscape,
+  subscribeMobileDeviceChange,
 } from "./mobileDevice";
 
 describe("resolveMobileDevice", () => {
@@ -35,7 +36,7 @@ describe("resolveMobileDevice", () => {
 });
 
 describe("resolveMobileViewportLandscape", () => {
-  it("prefers matchMedia when it is available", () => {
+  it("prefers screen orientation over viewport media queries", () => {
     expect(
       resolveMobileViewportLandscape({
         matchMediaLandscape: true,
@@ -43,10 +44,10 @@ describe("resolveMobileViewportLandscape", () => {
         innerWidth: 390,
         innerHeight: 844,
       })
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  it("falls back to screen orientation when matchMedia is unavailable", () => {
+  it("uses screen orientation when matchMedia is unavailable", () => {
     expect(
       resolveMobileViewportLandscape({
         orientationType: "landscape-primary",
@@ -56,7 +57,17 @@ describe("resolveMobileViewportLandscape", () => {
     ).toBe(true);
   });
 
-  it("falls back to viewport dimensions when orientation metadata is missing", () => {
+  it("falls back to matchMedia when screen orientation is unavailable", () => {
+    expect(
+      resolveMobileViewportLandscape({
+        matchMediaLandscape: true,
+        innerWidth: 390,
+        innerHeight: 844,
+      })
+    ).toBe(true);
+  });
+
+  it("falls back to layout viewport dimensions when orientation metadata is missing", () => {
     expect(
       resolveMobileViewportLandscape({
         innerWidth: 844,
@@ -64,15 +75,41 @@ describe("resolveMobileViewportLandscape", () => {
       })
     ).toBe(true);
   });
+});
 
-  it("uses visual viewport dimensions before layout viewport dimensions", () => {
-    expect(
-      resolveMobileViewportLandscape({
-        innerWidth: 390,
-        innerHeight: 844,
-        visualViewportWidth: 844,
-        visualViewportHeight: 390,
-      })
-    ).toBe(true);
+describe("subscribeMobileDeviceChange", () => {
+  it("ignores keyboard-driven viewport resizes", () => {
+    const screenOrientation = new EventTarget();
+    const visualViewport = new EventTarget();
+    const win = new EventTarget() as EventTarget & {
+      screen: { orientation: EventTarget };
+      visualViewport: EventTarget;
+    };
+    win.screen = { orientation: screenOrientation };
+    win.visualViewport = visualViewport;
+    let changeCount = 0;
+
+    const unsubscribe = subscribeMobileDeviceChange(
+      () => {
+        changeCount += 1;
+      },
+      win as unknown as Window
+    );
+
+    win.dispatchEvent(new Event("resize"));
+    visualViewport.dispatchEvent(new Event("resize"));
+
+    expect(changeCount).toBe(0);
+
+    win.dispatchEvent(new Event("orientationchange"));
+    screenOrientation.dispatchEvent(new Event("change"));
+
+    expect(changeCount).toBe(2);
+
+    unsubscribe();
+    win.dispatchEvent(new Event("orientationchange"));
+    screenOrientation.dispatchEvent(new Event("change"));
+
+    expect(changeCount).toBe(2);
   });
 });

--- a/src/lib/mobileDevice.test.ts
+++ b/src/lib/mobileDevice.test.ts
@@ -80,17 +80,22 @@ describe("subscribeMobileDeviceChange", () => {
     const screenOrientation = Object.assign(new EventTarget(), {
       type: "portrait-primary",
     });
-    const visualViewport = new EventTarget();
+    const visualViewport = Object.assign(new EventTarget(), {
+      height: 844,
+      width: 390,
+    });
     const win = new EventTarget() as EventTarget & {
       matchMedia: Window["matchMedia"];
+      innerHeight: number;
       innerWidth: number;
       screen: {
         height: number;
         orientation: EventTarget & { type: string };
         width: number;
       };
-      visualViewport: EventTarget;
+      visualViewport: EventTarget & { height: number; width: number };
     };
+    win.innerHeight = 844;
     win.innerWidth = 390;
     win.matchMedia = ((query: string) => ({
       matches:
@@ -125,6 +130,8 @@ describe("subscribeMobileDeviceChange", () => {
       win as unknown as Window
     );
 
+    win.innerHeight = 300;
+    visualViewport.height = 300;
     win.dispatchEvent(new Event("resize"));
     visualViewport.dispatchEvent(new Event("resize"));
 

--- a/src/lib/mobileDevice.test.ts
+++ b/src/lib/mobileDevice.test.ts
@@ -67,13 +67,19 @@ describe("resolveMobileViewportLandscape", () => {
     ).toBe(true);
   });
 
-  it("falls back to layout viewport dimensions when orientation metadata is missing", () => {
+  it("falls back to stable screen dimensions when orientation metadata is missing", () => {
     expect(
       resolveMobileViewportLandscape({
         innerWidth: 844,
         innerHeight: 390,
+        screenWidth: 844,
+        screenHeight: 390,
       })
     ).toBe(true);
+  });
+
+  it("returns false when no orientation metadata or stable dimensions are available", () => {
+    expect(resolveMobileViewportLandscape({})).toBe(false);
   });
 });
 
@@ -82,9 +88,11 @@ describe("subscribeMobileDeviceChange", () => {
     const screenOrientation = new EventTarget();
     const visualViewport = new EventTarget();
     const win = new EventTarget() as EventTarget & {
+      innerWidth: number;
       screen: { orientation: EventTarget };
       visualViewport: EventTarget;
     };
+    win.innerWidth = 390;
     win.screen = { orientation: screenOrientation };
     win.visualViewport = visualViewport;
     let changeCount = 0;
@@ -101,15 +109,22 @@ describe("subscribeMobileDeviceChange", () => {
 
     expect(changeCount).toBe(0);
 
+    win.innerWidth = 500;
+    win.dispatchEvent(new Event("resize"));
+
+    expect(changeCount).toBe(1);
+
     win.dispatchEvent(new Event("orientationchange"));
     screenOrientation.dispatchEvent(new Event("change"));
 
-    expect(changeCount).toBe(2);
+    expect(changeCount).toBe(3);
 
     unsubscribe();
+    win.innerWidth = 600;
+    win.dispatchEvent(new Event("resize"));
     win.dispatchEvent(new Event("orientationchange"));
     screenOrientation.dispatchEvent(new Event("change"));
 
-    expect(changeCount).toBe(2);
+    expect(changeCount).toBe(3);
   });
 });

--- a/src/lib/mobileDevice.ts
+++ b/src/lib/mobileDevice.ts
@@ -8,6 +8,8 @@ export type MobileViewportOrientation = {
   orientationType?: string;
   innerWidth?: number;
   innerHeight?: number;
+  screenWidth?: number;
+  screenHeight?: number;
 };
 
 const MOBILE_USER_AGENT_PATTERN =
@@ -50,8 +52,8 @@ const resolveLandscapeFromOrientationType = (
 export const resolveMobileViewportLandscape = ({
   matchMediaLandscape,
   orientationType,
-  innerWidth,
-  innerHeight,
+  screenWidth,
+  screenHeight,
 }: MobileViewportOrientation): boolean => {
   const orientationLandscape =
     resolveLandscapeFromOrientationType(orientationType);
@@ -64,11 +66,11 @@ export const resolveMobileViewportLandscape = ({
     return matchMediaLandscape;
   }
 
-  if (typeof innerWidth !== "number" || typeof innerHeight !== "number") {
+  if (typeof screenWidth !== "number" || typeof screenHeight !== "number") {
     return false;
   }
 
-  return innerWidth > innerHeight;
+  return screenWidth > screenHeight;
 };
 
 export const isMobileDevice = (win?: Window): boolean =>
@@ -86,6 +88,8 @@ export const isLandscapeViewport = (win?: Window): boolean => {
     orientationType: currentWindow.screen?.orientation?.type,
     innerWidth: currentWindow.innerWidth,
     innerHeight: currentWindow.innerHeight,
+    screenWidth: currentWindow.screen?.width,
+    screenHeight: currentWindow.screen?.height,
   });
 };
 
@@ -95,12 +99,23 @@ export const subscribeMobileDeviceChange = (
 ) => {
   const currentWindow = win ?? window;
   const screenOrientation = currentWindow.screen?.orientation;
+  let lastWidth = currentWindow.innerWidth;
+
+  const handleResize = () => {
+    if (currentWindow.innerWidth === lastWidth) {
+      return;
+    }
+    lastWidth = currentWindow.innerWidth;
+    onChange();
+  };
 
   currentWindow.addEventListener("orientationchange", onChange);
+  currentWindow.addEventListener("resize", handleResize);
   screenOrientation?.addEventListener?.("change", onChange);
 
   return () => {
     currentWindow.removeEventListener("orientationchange", onChange);
+    currentWindow.removeEventListener("resize", handleResize);
     screenOrientation?.removeEventListener?.("change", onChange);
   };
 };

--- a/src/lib/mobileDevice.ts
+++ b/src/lib/mobileDevice.ts
@@ -6,8 +6,6 @@ export type MobileDeviceCapabilities = {
 export type MobileViewportOrientation = {
   matchMediaLandscape?: boolean;
   orientationType?: string;
-  innerWidth?: number;
-  innerHeight?: number;
   screenWidth?: number;
   screenHeight?: number;
 };
@@ -86,8 +84,6 @@ export const isLandscapeViewport = (win?: Window): boolean => {
   return resolveMobileViewportLandscape({
     matchMediaLandscape,
     orientationType: currentWindow.screen?.orientation?.type,
-    innerWidth: currentWindow.innerWidth,
-    innerHeight: currentWindow.innerHeight,
     screenWidth: currentWindow.screen?.width,
     screenHeight: currentWindow.screen?.height,
   });
@@ -99,23 +95,27 @@ export const subscribeMobileDeviceChange = (
 ) => {
   const currentWindow = win ?? window;
   const screenOrientation = currentWindow.screen?.orientation;
-  let lastWidth = currentWindow.innerWidth;
+  let lastLandscape = isLandscapeViewport(currentWindow);
 
-  const handleResize = () => {
-    if (currentWindow.innerWidth === lastWidth) {
+  const handleOrientationChange = () => {
+    const nextLandscape = isLandscapeViewport(currentWindow);
+    if (nextLandscape === lastLandscape) {
       return;
     }
-    lastWidth = currentWindow.innerWidth;
+    lastLandscape = nextLandscape;
     onChange();
   };
 
-  currentWindow.addEventListener("orientationchange", onChange);
-  currentWindow.addEventListener("resize", handleResize);
-  screenOrientation?.addEventListener?.("change", onChange);
+  currentWindow.addEventListener("orientationchange", handleOrientationChange);
+  currentWindow.addEventListener("resize", handleOrientationChange);
+  screenOrientation?.addEventListener?.("change", handleOrientationChange);
 
   return () => {
-    currentWindow.removeEventListener("orientationchange", onChange);
-    currentWindow.removeEventListener("resize", handleResize);
-    screenOrientation?.removeEventListener?.("change", onChange);
+    currentWindow.removeEventListener(
+      "orientationchange",
+      handleOrientationChange
+    );
+    currentWindow.removeEventListener("resize", handleOrientationChange);
+    screenOrientation?.removeEventListener?.("change", handleOrientationChange);
   };
 };

--- a/src/lib/mobileDevice.ts
+++ b/src/lib/mobileDevice.ts
@@ -8,8 +8,6 @@ export type MobileViewportOrientation = {
   orientationType?: string;
   innerWidth?: number;
   innerHeight?: number;
-  visualViewportWidth?: number;
-  visualViewportHeight?: number;
 };
 
 const MOBILE_USER_AGENT_PATTERN =
@@ -54,13 +52,7 @@ export const resolveMobileViewportLandscape = ({
   orientationType,
   innerWidth,
   innerHeight,
-  visualViewportWidth,
-  visualViewportHeight,
 }: MobileViewportOrientation): boolean => {
-  if (typeof matchMediaLandscape === "boolean") {
-    return matchMediaLandscape;
-  }
-
   const orientationLandscape =
     resolveLandscapeFromOrientationType(orientationType);
 
@@ -68,20 +60,15 @@ export const resolveMobileViewportLandscape = ({
     return orientationLandscape;
   }
 
-  const viewportWidth =
-    typeof visualViewportWidth === "number" && visualViewportWidth > 0
-      ? visualViewportWidth
-      : innerWidth;
-  const viewportHeight =
-    typeof visualViewportHeight === "number" && visualViewportHeight > 0
-      ? visualViewportHeight
-      : innerHeight;
+  if (typeof matchMediaLandscape === "boolean") {
+    return matchMediaLandscape;
+  }
 
-  if (typeof viewportWidth !== "number" || typeof viewportHeight !== "number") {
+  if (typeof innerWidth !== "number" || typeof innerHeight !== "number") {
     return false;
   }
 
-  return viewportWidth > viewportHeight;
+  return innerWidth > innerHeight;
 };
 
 export const isMobileDevice = (win?: Window): boolean =>
@@ -99,8 +86,6 @@ export const isLandscapeViewport = (win?: Window): boolean => {
     orientationType: currentWindow.screen?.orientation?.type,
     innerWidth: currentWindow.innerWidth,
     innerHeight: currentWindow.innerHeight,
-    visualViewportWidth: currentWindow.visualViewport?.width,
-    visualViewportHeight: currentWindow.visualViewport?.height,
   });
 };
 
@@ -110,17 +95,12 @@ export const subscribeMobileDeviceChange = (
 ) => {
   const currentWindow = win ?? window;
   const screenOrientation = currentWindow.screen?.orientation;
-  const visualViewport = currentWindow.visualViewport;
 
   currentWindow.addEventListener("orientationchange", onChange);
-  currentWindow.addEventListener("resize", onChange);
   screenOrientation?.addEventListener?.("change", onChange);
-  visualViewport?.addEventListener("resize", onChange);
 
   return () => {
     currentWindow.removeEventListener("orientationchange", onChange);
-    currentWindow.removeEventListener("resize", onChange);
     screenOrientation?.removeEventListener?.("change", onChange);
-    visualViewport?.removeEventListener("resize", onChange);
   };
 };


### PR DESCRIPTION
## Summary

- ignore keyboard-driven layout and visual viewport resize events when synchronizing mobile orientation state
- keep `ContentRender` custom renderer component identities stable across overlay rerenders
- reset interaction input defaults only when the interaction definition or defaults actually change
- add mobile browser coverage that verifies the focused textarea node, focus, and typed value survive a virtual viewport resize

## Root cause

Opening the mobile virtual keyboard triggered the resize listeners used by Slide's mobile viewport synchronization. The resulting overlay layout compensation could update drag state and rerender the memoized interaction card. `ContentRender` recreated its `components` object and inline `custom-variable` renderer on every render, so React unmounted and rebuilt the textarea. The new AST node reference could also resynchronize defaults and clear in-progress input.

## Impact

Learners can continue typing in Slide interaction overlays without the virtual keyboard immediately closing. Real orientation events, manual mobile fullscreen switching, overlay dragging, buttons, multi-select inputs, and interaction defaults remain supported.

## Validation

- `npx vitest run --project unit` — 192 tests passed
- targeted Chromium Storybook tests — mobile drag and mobile input viewport resize passed
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npx tsc --noEmit --pretty false`
- `npm run typecheck:exports`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile interaction behavior during virtual viewport resizing, preserving focus, typed content, and element continuity.
  * Prevented unnecessary input resets when unrelated content properties change.
  * Improved landscape detection across orientation and screen-size scenarios.
  * Reduced duplicate mobile orientation notifications.

* **Tests**
  * Added Storybook coverage for focus retention during prop churn.
  * Added coverage for mobile viewport resize interaction and mobile orientation-change handling/unsubscribe behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->