### PR TITLE
chore: release markdown-flow-ui 0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.2.7 - 2026-07-28
+
+### Fixed
+
+- Kept slide interaction inputs focused across parent re-renders, callback updates, equivalent default-value arrays, mobile keyboard viewport resizes, and duplicate orientation events.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-flow-ui",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-flow-ui",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
       ]
     }
   },
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary

- Release `markdown-flow-ui@0.2.7` after the mobile slide input focus fix was merged.
- Update `package.json` and `package-lock.json` to the published release version.

## Validation

- Publish (manual) workflow completed successfully and published `markdown-flow-ui@0.2.7` on the `latest` dist-tag.
- Confirmed `npm view markdown-flow-ui` reports latest/version as `0.2.7`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slide interaction focus during parent updates and callback changes.
  * Improved handling of equivalent default-value arrays.
  * Enhanced mobile keyboard viewport resizing behavior.
  * Prevented duplicate orientation events.

* **Chores**
  * Updated the package to version 0.2.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->